### PR TITLE
Closes #8: Add vscode helper functions

### DIFF
--- a/.github/instructions/global.instructions.md
+++ b/.github/instructions/global.instructions.md
@@ -1,0 +1,6 @@
+---
+applyTo: "**"
+---
+
+Use npm for package management.
+When you install npm packages, make sure to be on node version 22. You can switch versions using nvm: `nvm use 22`.

--- a/.github/instructions/ts.instructions.md
+++ b/.github/instructions/ts.instructions.md
@@ -1,0 +1,11 @@
+---
+applyTo: "**/*.ts"
+---
+
+Prefer arrow functions.
+Use examples, if appropriate, in documentations.
+Use descriptive variable names with auxiliary verbs (e.g., isLoading, hasError).
+Favor named exports.
+Use camelCase for file names that are not React components. Use PascalCase for React component file names.
+When changing existing code, don't remove comments, except if asked to do so. Instead, update them to reflect the new code, if necessary.
+Use early returns whenever possible to make the code more readable.

--- a/.github/prompts/license.prompt.md
+++ b/.github/prompts/license.prompt.md
@@ -1,0 +1,19 @@
+---
+mode: "edit"
+---
+
+Add a license file header to the document. It should have this structure:
+
+```
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+```
+
+Make sure to adapt the comment style to the language of the file. For example, if it is a Markdown file, use `<!-- -->` for comments. If it is a YAML file, use `#` for comments.
+Use line comments for these languages: javascript, typescript, javascriptreact, typescriptreact, dockerfile, yaml, jsonc.
+Block comments for everything else.

--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,4 @@ eslint_report.json
 
 # editors
 .idea/
-.vscode/
+.vscode/settings.json

--- a/.vscode/license.code-snippets
+++ b/.vscode/license.code-snippets
@@ -1,0 +1,41 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+{
+  "Add license header (line comment)": {
+    "prefix": "license",
+    "description": "Add license header",
+    "scope": "javascript,typescript,javascriptreact,typescriptreact,dockerfile,yaml,jsonc",
+    "body": [
+      "$LINE_COMMENT",
+      "$LINE_COMMENT This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project",
+      "$LINE_COMMENT",
+      "$LINE_COMMENT SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)",
+      "$LINE_COMMENT",
+      "$LINE_COMMENT SPDX-License-Identifier: MIT",
+      "$LINE_COMMENT",
+      "",
+      "$1",
+    ],
+  },
+  "Add license header (block comment)": {
+    "prefix": "license",
+    "description": "Add license header",
+    "scope": "html,css,scss,sass,less,markdown,plaintext",
+    "body": [
+      "$BLOCK_COMMENT_START",
+      "This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project",
+      "",
+      "SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)",
+      "",
+      "SPDX-License-Identifier: MIT",
+      "$BLOCK_COMMENT_END",
+      "",
+      "$1",
+    ],
+  },
+}


### PR DESCRIPTION
# Add vscode helper functions

## :recycle: Current situation & Problem
The repo is missing helpers for creating license headers and instructions for Github Copilot.

## :gear: Release Notes
- Added Github Copilot instructions to give the LLM more information about the particularities of the repository (e.g. node version, package manager) and typescript guidelines (`.github/instructions`).
- Added a Github Copilot prompt to generate a license header `.github/prompts`).
- Created a VS Code snippet for quickly adding license headers for various file types (`.vscode/license.code-snippets`).

## :white_check_mark: Testing
No testing necessary.

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).