### PR TITLE
Closes #15: Add components and styling to the dashboard layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@tanstack/react-router": "^1.117.1",
         "react": "^19",
         "react-dom": "^19",
+        "tailwind-merge": "^3.3.0",
         "tailwindcss": "^4.1.7"
       },
       "devDependencies": {
@@ -10754,6 +10755,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.0.tgz",
+      "integrity": "sha512-fyW/pEfcQSiigd5SNn0nApUOxx0zB/dm6UDU/rEwc2c3sX2smWUNbapHv+QRqLGVp9GWX3THIa7MUGPo+YkDzQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@radix-ui/react-slot": "^1.2.3",
         "@stanfordspezi/spezi-web-design-system": "^0.12.0",
         "@tailwindcss/vite": "^4.1.7",
         "@tanstack/react-router": "^1.117.1",
+        "class-variance-authority": "^0.7.1",
         "react": "^19",
         "react-dom": "^19",
         "tailwind-merge": "^3.3.0",
@@ -2652,6 +2654,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.2.tgz",
+      "integrity": "sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.6.tgz",
@@ -2811,6 +2831,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.2.tgz",
+      "integrity": "sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
@@ -2901,6 +2939,24 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.2.tgz",
+      "integrity": "sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -3156,6 +3212,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.2.tgz",
+      "integrity": "sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-menubar": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.14.tgz",
@@ -3325,6 +3399,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.2.tgz",
+      "integrity": "sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-popper": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.6.tgz",
@@ -3424,6 +3516,24 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.2.tgz",
+      "integrity": "sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -3589,6 +3699,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.2.tgz",
+      "integrity": "sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-separator": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.6.tgz",
@@ -3646,9 +3774,9 @@
       }
     },
     "node_modules/@radix-ui/react-slot": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.2.tgz",
-      "integrity": "sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
@@ -3869,6 +3997,24 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.2.tgz",
+      "integrity": "sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -9868,6 +10014,24 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/radix-ui/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.2.tgz",
+      "integrity": "sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@tanstack/react-router": "^1.117.1",
     "react": "^19",
     "react-dom": "^19",
+    "tailwind-merge": "^3.3.0",
     "tailwindcss": "^4.1.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,9 +31,11 @@
     "test": "playwright test"
   },
   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3",
     "@stanfordspezi/spezi-web-design-system": "^0.12.0",
     "@tailwindcss/vite": "^4.1.7",
     "@tanstack/react-router": "^1.117.1",
+    "class-variance-authority": "^0.7.1",
     "react": "^19",
     "react-dom": "^19",
     "tailwind-merge": "^3.3.0",

--- a/src/components/interfaces/Header/Header.tsx
+++ b/src/components/interfaces/Header/Header.tsx
@@ -1,0 +1,23 @@
+import { cn } from "@/utils/cn";
+
+export const Header = () => {
+  return (
+    <header
+      className={cn(
+        "fixed top-0 z-10",
+        "flex h-14 w-full items-center justify-between gap-2 pr-3 pl-2",
+        "bg-bg border-border border-b",
+      )}
+    >
+      <div className="flex items-center gap-3">
+        <div>team</div>
+        <div className="bg-border h-5 w-px rotate-12 rounded-full"></div>
+        <div>study</div>
+      </div>
+      <div className="flex items-center gap-2">
+        <div className="text-muted-foreground text-sm">User Name</div>
+        <div className="bg-fill-brand h-8 w-8 rounded-full"></div>
+      </div>
+    </header>
+  );
+};

--- a/src/components/interfaces/Header/Header.tsx
+++ b/src/components/interfaces/Header/Header.tsx
@@ -1,4 +1,8 @@
 import { cn } from "@/utils/cn";
+import { Notifications } from "./Notifications";
+import { StudySelector } from "./StudySelector";
+import { TeamSelector } from "./TeamSelector";
+import { UserDropdown } from "./UserDropdown";
 
 export const Header = () => {
   return (
@@ -10,13 +14,13 @@ export const Header = () => {
       )}
     >
       <div className="flex items-center gap-3">
-        <div>team</div>
+        <TeamSelector />
         <div className="bg-border h-5 w-px rotate-12 rounded-full"></div>
-        <div>study</div>
+        <StudySelector />
       </div>
       <div className="flex items-center gap-2">
-        <div className="text-muted-foreground text-sm">User Name</div>
-        <div className="bg-fill-brand h-8 w-8 rounded-full"></div>
+        <Notifications />
+        <UserDropdown />
       </div>
     </header>
   );

--- a/src/components/interfaces/Header/HeaderSelector.tsx
+++ b/src/components/interfaces/Header/HeaderSelector.tsx
@@ -63,7 +63,7 @@ export const HeaderSelector = ({
             "flex h-8 items-center gap-3 rounded-md p-2.5 text-left text-sm outline-hidden",
             "hover:bg-bg-hover",
             "disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50",
-            "focus-visible:ring-2",
+            "focus-visible:ring-border-focus focus-visible:ring-2",
             "[&>span:last-child]:truncate",
             "[&>svg]:size-3.5 [&>svg]:shrink-0",
           )}

--- a/src/components/interfaces/Header/HeaderSelector.tsx
+++ b/src/components/interfaces/Header/HeaderSelector.tsx
@@ -60,7 +60,7 @@ export const HeaderSelector = ({
       <DropdownMenuTrigger asChild>
         <button
           className={cn(
-            "flex h-8 items-center gap-3 rounded-md p-2.5 text-left text-sm outline-hidden",
+            "flex h-8 items-center gap-3 rounded-md p-2.5 text-left text-sm outline-hidden transition-colors",
             "hover:bg-bg-hover",
             "disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50",
             "focus-visible:ring-border-focus focus-visible:ring-2",

--- a/src/components/interfaces/Header/HeaderSelector.tsx
+++ b/src/components/interfaces/Header/HeaderSelector.tsx
@@ -1,0 +1,94 @@
+import {
+  Link,
+  type RegisteredRouter,
+  type ValidateLinkOptions,
+} from "@tanstack/react-router";
+import { ChevronsUpDown, type LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/DropdownMenu";
+import { cn } from "@/utils/cn";
+
+export const HeaderSelectorMenuLabel = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  return <DropdownMenuLabel className="text-xs">{children}</DropdownMenuLabel>;
+};
+
+export const HeaderSelectorMenuItem = <
+  TRouter extends RegisteredRouter = RegisteredRouter,
+  TOptions = unknown,
+>({
+  children,
+  icon: LucideIcon,
+  linkOptions,
+}: {
+  children: React.ReactNode;
+  icon?: LucideIcon;
+  linkOptions: ValidateLinkOptions<TRouter, TOptions>;
+}) => {
+  return (
+    <DropdownMenuItem className="gap-2 p-2!" asChild>
+      <Link {...linkOptions}>
+        {LucideIcon && (
+          <div className="flex size-6 items-center justify-center rounded-sm border">
+            <LucideIcon className="size-4 shrink-0" />
+          </div>
+        )}
+        {children}
+      </Link>
+    </DropdownMenuItem>
+  );
+};
+
+export const HeaderSelector = ({
+  selectedItem,
+  children,
+}: {
+  selectedItem: { title: string; icon?: LucideIcon };
+  children: React.ReactNode;
+}) => {
+  return (
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <button
+          className={cn(
+            "flex h-8 items-center gap-3 rounded-md p-2.5 text-left text-sm outline-hidden",
+            "hover:bg-bg-hover",
+            "disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50",
+            "focus-visible:ring-2",
+            "[&>span:last-child]:truncate",
+            "[&>svg]:size-3.5 [&>svg]:shrink-0",
+          )}
+        >
+          {selectedItem.icon && (
+            <div className="bg-surface ring-border-shadow -ml-1.5 flex aspect-square size-6 items-center justify-center rounded-md shadow-xs ring">
+              <selectedItem.icon className="size-3.5" strokeWidth={2} />
+            </div>
+          )}
+          <div className="grid flex-1 text-left text-sm leading-tight">
+            <span className="truncate">{selectedItem.title}</span>
+          </div>
+          <ChevronsUpDown className="text-icon-tertiary ml-auto" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        // I need to add the "important" flag because the Spezi components don't allow
+        // you to overwrite tailwind classes
+        className="min-w-60! rounded-lg"
+        align="start"
+        side="bottom"
+        sideOffset={4}
+      >
+        {children}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/src/components/interfaces/Header/HeaderSelectorSkeleton.tsx
+++ b/src/components/interfaces/Header/HeaderSelectorSkeleton.tsx
@@ -1,0 +1,28 @@
+import { ChevronsUpDown } from "lucide-react";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { cn } from "@/utils/cn";
+
+export const HeaderSelectorSkeleton = ({ hasIcon }: { hasIcon: boolean }) => {
+  return (
+    <div
+      className={cn(
+        "flex h-8 items-center gap-3 rounded-md p-2.5 text-left text-sm outline-hidden",
+        "hover:bg-bg-hover",
+        "disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50",
+        "focus-visible:ring-2",
+        "[&>span:last-child]:truncate",
+        "[&>svg]:size-3.5 [&>svg]:shrink-0",
+      )}
+    >
+      {hasIcon && (
+        <div className="bg-surface ring-border-shadow -ml-1.5 flex aspect-square size-6 items-center justify-center rounded-md shadow-xs ring">
+          <div className="size-3.5" />
+        </div>
+      )}
+      <div className="grid h-4 w-20 flex-1">
+        <Skeleton className="bg-fill-tertiary size-full rounded-sm" />
+      </div>
+      <ChevronsUpDown className="ml-auto" />
+    </div>
+  );
+};

--- a/src/components/interfaces/Header/Notifications.tsx
+++ b/src/components/interfaces/Header/Notifications.tsx
@@ -1,0 +1,33 @@
+import { Bell } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/Sheet";
+
+export const Notifications = () => {
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Notifications"
+          className="size-8"
+        >
+          <Bell />
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="right">
+        <SheetHeader>
+          <SheetTitle>Notifications</SheetTitle>
+          <SheetDescription>You have no new notifications.</SheetDescription>
+        </SheetHeader>
+      </SheetContent>
+    </Sheet>
+  );
+};

--- a/src/components/interfaces/Header/StudySelector.tsx
+++ b/src/components/interfaces/Header/StudySelector.tsx
@@ -1,0 +1,80 @@
+import { useParams } from "@tanstack/react-router";
+import { Plus } from "lucide-react";
+import { DropdownMenuSeparator } from "@/components/ui/DropdownMenu";
+import {
+  HeaderSelector,
+  HeaderSelectorMenuItem,
+  HeaderSelectorMenuLabel,
+} from "./HeaderSelector";
+
+const studies = [
+  {
+    id: "activity-study",
+    title: "Activity Study",
+    shortTitle: "Activity",
+    explanation: "This is a study about activity.",
+    shortExplanation: "Study about activity.",
+    participationCriteria: "Must be over 18 years old.",
+  },
+  {
+    id: "health-study",
+    title: "Health Study",
+    shortTitle: "Health",
+    explanation: "This is a study about health.",
+    shortExplanation: "Study about health.",
+    participationCriteria: null,
+  },
+  {
+    id: "brain-study",
+    title: "Brain Study",
+    shortTitle: "Brain",
+    explanation: "This is a study about the brain.",
+    shortExplanation: "Study about the brain.",
+    participationCriteria: null,
+  },
+  {
+    id: "dna-study",
+    title: "DNA Study",
+    shortTitle: "DNA",
+    explanation: "This is a study about DNA.",
+    shortExplanation: "Study about DNA.",
+    participationCriteria: null,
+  },
+];
+
+export const StudySelector = () => {
+  const { team, study } = useParams({ from: "/(dashboard)/$team/$study" });
+  const selectedStudy = studies.find((s) => s.id === study);
+
+  // if (!studies) {
+  //   return <HeaderSelectorSkeleton hasIcon={false} />
+  // }
+
+  return (
+    <HeaderSelector
+      selectedItem={{
+        title: selectedStudy?.title ?? studies[0].title,
+      }}
+    >
+      <HeaderSelectorMenuLabel>Studies</HeaderSelectorMenuLabel>
+      {studies.map((study) => (
+        <HeaderSelectorMenuItem
+          key={study.id}
+          linkOptions={{
+            to: "/$team/$study",
+            params: {
+              team,
+              study: study.id,
+            },
+          }}
+        >
+          {study.title}
+        </HeaderSelectorMenuItem>
+      ))}
+      <DropdownMenuSeparator />
+      <HeaderSelectorMenuItem icon={Plus} linkOptions={{ to: "." }}>
+        Add Study
+      </HeaderSelectorMenuItem>
+    </HeaderSelector>
+  );
+};

--- a/src/components/interfaces/Header/TeamSelector.tsx
+++ b/src/components/interfaces/Header/TeamSelector.tsx
@@ -1,0 +1,92 @@
+import { useParams } from "@tanstack/react-router";
+import {
+  Flower,
+  Mountain,
+  Plus,
+  TentTree,
+  TreePalm,
+  TreePine,
+  type LucideIcon,
+} from "lucide-react";
+import { DropdownMenuSeparator } from "@/components/ui/DropdownMenu";
+import {
+  HeaderSelector,
+  HeaderSelectorMenuItem,
+  HeaderSelectorMenuLabel,
+} from "./HeaderSelector";
+// import { DropdownSelectorSkeleton } from "./DropdownSelectorSkeleton";
+
+const iconMap: Record<string, LucideIcon> = {
+  TreePine: TreePine,
+  TentTree: TentTree,
+  TreePalm: TreePalm,
+  Flower: Flower,
+  Mountain: Mountain,
+};
+
+const teams = [
+  {
+    id: "team-pine",
+    name: "Team Pine",
+    icon: "TreePine",
+  },
+  {
+    id: "team-tree",
+    name: "Team Tree",
+    icon: "TentTree",
+  },
+  {
+    id: "team-palm",
+    name: "Team Palm",
+    icon: "TreePalm",
+  },
+  {
+    id: "team-flower",
+    name: "Team Flower",
+    icon: "Flower",
+  },
+  {
+    id: "team-mountain",
+    name: "Team Mountain",
+    icon: "Mountain",
+  },
+];
+
+export const TeamSelector = () => {
+  const { team } = useParams({ from: "/(dashboard)/$team/$study" });
+  const selectedTeam = teams.find((t) => t.id === team);
+
+  //   if (!teams) {
+  //     return <HeaderSelectorSkeleton hasIcon={true} />;
+  //   }
+
+  return (
+    <HeaderSelector
+      selectedItem={{
+        title: selectedTeam?.name ?? teams[0].name,
+        icon: iconMap[selectedTeam?.icon ?? teams[0].icon] ?? TreePine,
+      }}
+    >
+      <HeaderSelectorMenuLabel>Teams</HeaderSelectorMenuLabel>
+      {teams.map((team) => (
+        <HeaderSelectorMenuItem
+          key={team.id}
+          icon={iconMap[team.icon] ?? TreePine}
+          linkOptions={{
+            to: "/$team/$study",
+            params: {
+              team: team.id,
+              study: "activity-study", // Todo: This should be dynamic based on the selected team
+            },
+          }}
+        >
+          {team.name}
+        </HeaderSelectorMenuItem>
+      ))}
+      <DropdownMenuSeparator />
+      <HeaderSelectorMenuItem icon={Plus} linkOptions={{ to: "." }}>
+        <span className="text-muted-foreground">Add Team</span>
+      </HeaderSelectorMenuItem>
+    </HeaderSelector>
+  );
+};

--- a/src/components/interfaces/Header/UserDropdown.tsx
+++ b/src/components/interfaces/Header/UserDropdown.tsx
@@ -56,7 +56,7 @@ export const UserDropdown = () => {
         sideOffset={4}
       >
         <DropdownMenuLabel>
-          <div className="text-text-secondary">{session.user.name}</div>
+          <div>{session.user.name}</div>
           <div className="text-text-tertiary truncate">
             {session.user.email}
           </div>

--- a/src/components/interfaces/Header/UserDropdown.tsx
+++ b/src/components/interfaces/Header/UserDropdown.tsx
@@ -1,0 +1,83 @@
+import { Layers2, LogOut, User } from "lucide-react";
+import { Avatar } from "@/components/ui/Avatar";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/DropdownMenu";
+import { cn } from "@/utils/cn";
+// import { UserDropdownSkeleton } from "./UserDropdownSkeleton";
+
+const session = {
+  user: {
+    name: "John Doe",
+    email: "john@example.com",
+    image: undefined,
+  },
+};
+
+export const UserDropdown = () => {
+  // if (!session) {
+  //   return <UserDropdownSkeleton />;
+  // }
+
+  return (
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <button
+          className={cn(
+            "flex h-8 items-center gap-3 rounded-md p-1 text-left text-sm outline-hidden",
+            "hover:bg-bg-hover",
+            "disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50",
+            "focus-visible:ring-2",
+          )}
+        >
+          <Avatar
+            // I need to add the "important" flag because the Spezi components don't allow
+            // you to overwrite tailwind classes
+            className="bg-surface ring-border-shadow size-6.5! rounded-full shadow-xs ring"
+            src={session.user.image}
+            fallback={
+              <div className="bg-surface flex-center size-full rounded-full text-xs">
+                {session.user.name[0].toUpperCase()}
+              </div>
+            }
+          />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        className="min-w-60! rounded-lg"
+        side="top"
+        align="end"
+        sideOffset={4}
+      >
+        <DropdownMenuLabel>
+          <div className="text-text-secondary">{session.user.name}</div>
+          <div className="text-text-tertiary truncate">
+            {session.user.email}
+          </div>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuGroup>
+          <DropdownMenuItem>
+            <User className="size-3.5" />
+            Profile Settings
+          </DropdownMenuItem>
+          <DropdownMenuItem>
+            <Layers2 />
+            Shortcuts
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem>
+          <LogOut />
+          Log out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/src/components/interfaces/Header/UserDropdown.tsx
+++ b/src/components/interfaces/Header/UserDropdown.tsx
@@ -33,7 +33,7 @@ export const UserDropdown = () => {
             "flex h-8 items-center gap-3 rounded-md p-1 text-left text-sm outline-hidden",
             "hover:bg-bg-hover",
             "disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50",
-            "focus-visible:ring-2",
+            "focus-visible:ring-border-focus focus-visible:ring-2",
           )}
         >
           <Avatar

--- a/src/components/interfaces/Header/UserDropdownSkeleton.tsx
+++ b/src/components/interfaces/Header/UserDropdownSkeleton.tsx
@@ -1,0 +1,22 @@
+import { Avatar } from "@/components/ui/Avatar";
+import { cn } from "@/utils/cn";
+
+export const UserDropdownSkeleton = () => {
+  return (
+    <div
+      className={cn(
+        "flex h-8 items-center gap-3 rounded-md p-1 text-left text-sm outline-hidden",
+        "hover:bg-bg-hover",
+        "disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50",
+        "focus-visible:ring-2",
+        "[&>span:last-child]:truncate",
+        "[&>svg]:size-3.5 [&>svg]:shrink-0",
+      )}
+    >
+      <Avatar
+        className="bg-surface ring-border-shadow size-6.5 rounded-full shadow-xs ring"
+        fallback={<div className="bg-surface rounded-lg text-xs" />}
+      />
+    </div>
+  );
+};

--- a/src/components/interfaces/Sidebar/AppSidebar.tsx
+++ b/src/components/interfaces/Sidebar/AppSidebar.tsx
@@ -1,0 +1,28 @@
+import { FooterNav } from "./FooterNav";
+import { MainNav } from "./MainNav";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarRail,
+  SidebarSeparator,
+} from "./Sidebar";
+
+interface Props {
+  className?: string;
+}
+
+export const AppSidebar = ({ className }: Props) => {
+  return (
+    <Sidebar collapsible="icon" className={className}>
+      <SidebarContent>
+        <MainNav />
+      </SidebarContent>
+      <SidebarSeparator className="border-border mx-0 border-t border-dashed bg-transparent" />
+      <SidebarFooter className="px-0">
+        <FooterNav />
+      </SidebarFooter>
+      <SidebarRail />
+    </Sidebar>
+  );
+};

--- a/src/components/interfaces/Sidebar/FooterNav.tsx
+++ b/src/components/interfaces/Sidebar/FooterNav.tsx
@@ -1,0 +1,57 @@
+import {
+  HelpCircle,
+  MessageCircle,
+  PanelLeft,
+  type LucideIcon,
+} from "lucide-react";
+import {
+  SidebarGroup,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  useSidebar,
+} from "./Sidebar";
+
+interface NavBarItem {
+  id?: string;
+  title: string;
+  icon?: LucideIcon;
+}
+
+const navBarItems: NavBarItem[] = [
+  {
+    id: "feedback",
+    title: "Feedback",
+    icon: MessageCircle,
+  },
+  {
+    id: "help",
+    title: "Help",
+    icon: HelpCircle,
+  },
+];
+
+export const FooterNav = () => {
+  const { toggleSidebar } = useSidebar();
+
+  return (
+    <SidebarGroup>
+      <SidebarMenu>
+        {navBarItems.map((item) => (
+          <SidebarMenuItem key={item.id}>
+            <SidebarMenuButton tooltip={item.title}>
+              {item.icon && <item.icon />}
+              <span>{item.title}</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        ))}
+        <SidebarMenuItem>
+          <SidebarMenuButton tooltip="Expand Sidebar" onClick={toggleSidebar}>
+            <PanelLeft />
+            <span>Collapse</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    </SidebarGroup>
+  );
+};

--- a/src/components/interfaces/Sidebar/MainNav.tsx
+++ b/src/components/interfaces/Sidebar/MainNav.tsx
@@ -1,0 +1,97 @@
+import {
+  Link,
+  useMatchRoute,
+  type ValidateLinkOptions,
+} from "@tanstack/react-router";
+import {
+  Bolt,
+  ChartBar,
+  Home,
+  Search,
+  Users,
+  type LucideIcon,
+} from "lucide-react";
+import {
+  SidebarGroup,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "./Sidebar";
+
+interface NavBarItem {
+  id?: string;
+  title: string;
+  linkOptions?: ValidateLinkOptions;
+  icon?: LucideIcon;
+}
+
+const navBarItems: NavBarItem[] = [
+  {
+    id: "search",
+    title: "Search",
+    icon: Search,
+  },
+  {
+    id: "home",
+    title: "Home",
+    icon: Home,
+    linkOptions: { to: "/$team/$study" },
+  },
+  {
+    id: "configuration",
+    title: "Configuration",
+    icon: Bolt,
+    linkOptions: { to: "/$team/$study/configuration" },
+  },
+  {
+    id: "participants",
+    title: "Participants",
+    icon: Users,
+    linkOptions: { to: "/$team/$study/participants" },
+  },
+  {
+    id: "results",
+    title: "Results",
+    icon: ChartBar,
+    linkOptions: { to: "/$team/$study/results" },
+  },
+];
+
+const MainNavButton = ({ item }: { item: NavBarItem }) => {
+  const matchRoute = useMatchRoute();
+  if (item.linkOptions) {
+    return (
+      <SidebarMenuButton
+        asChild
+        tooltip={item.title}
+        isActive={!!matchRoute({ to: item.linkOptions.to })}
+      >
+        <Link {...item.linkOptions}>
+          {item.icon && <item.icon />}
+          <span>{item.title}</span>
+        </Link>
+      </SidebarMenuButton>
+    );
+  }
+
+  return (
+    <SidebarMenuButton tooltip={item.title}>
+      {item.icon && <item.icon />}
+      <span>{item.title}</span>
+    </SidebarMenuButton>
+  );
+};
+
+export const MainNav = () => {
+  return (
+    <SidebarGroup>
+      <SidebarMenu>
+        {navBarItems.map((item) => (
+          <SidebarMenuItem key={item.id}>
+            <MainNavButton item={item} />
+          </SidebarMenuItem>
+        ))}
+      </SidebarMenu>
+    </SidebarGroup>
+  );
+};

--- a/src/components/interfaces/Sidebar/Sidebar.tsx
+++ b/src/components/interfaces/Sidebar/Sidebar.tsx
@@ -1,0 +1,727 @@
+// Adapted from shadcn/ui
+
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import { PanelLeftIcon } from "lucide-react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ComponentProps,
+} from "react";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { Separator } from "@/components/ui/Separator";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/Sheet";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { Tooltip, TooltipProvider } from "@/components/ui/Tooltip";
+import { cn } from "@/utils/cn";
+import { useIsMobile } from "@/utils/useIsMobile";
+
+const SIDEBAR_COOKIE_NAME = "sidebar_state";
+const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
+const SIDEBAR_WIDTH = "14rem";
+const SIDEBAR_WIDTH_MOBILE = "18rem";
+const SIDEBAR_WIDTH_ICON = "3rem";
+const SIDEBAR_KEYBOARD_SHORTCUT = "b";
+
+interface SidebarContextProps {
+  state: "expanded" | "collapsed";
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  openMobile: boolean;
+  setOpenMobile: (open: boolean) => void;
+  isMobile: boolean;
+  toggleSidebar: () => void;
+}
+
+const SidebarContext = createContext<SidebarContextProps | null>(null);
+
+const useSidebar = () => {
+  const context = useContext(SidebarContext);
+  if (!context) {
+    throw new Error("useSidebar must be used within a SidebarProvider.");
+  }
+
+  return context;
+};
+
+const SidebarProvider = ({
+  defaultOpen = true,
+  open: openProp,
+  onOpenChange: setOpenProp,
+  className,
+  style,
+  children,
+  ...props
+}: ComponentProps<"div"> & {
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}) => {
+  const isMobile = useIsMobile();
+  const [openMobile, setOpenMobile] = useState(false);
+
+  // This is the internal state of the sidebar.
+  // We use openProp and setOpenProp for control from outside the component.
+  const [_open, _setOpen] = useState(defaultOpen);
+  const open = openProp ?? _open;
+  const setOpen = useCallback(
+    (value: boolean | ((value: boolean) => boolean)) => {
+      const openState = typeof value === "function" ? value(open) : value;
+      if (setOpenProp) {
+        setOpenProp(openState);
+      } else {
+        _setOpen(openState);
+      }
+
+      // This sets the cookie to keep the sidebar state.
+      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+    },
+    [setOpenProp, open],
+  );
+
+  // Helper to toggle the sidebar.
+  const toggleSidebar = useCallback(() => {
+    if (isMobile) {
+      setOpenMobile((open) => !open);
+    } else {
+      setOpen((open) => !open);
+    }
+  }, [isMobile, setOpen, setOpenMobile]);
+
+  // Adds a keyboard shortcut to toggle the sidebar.
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
+        (event.metaKey || event.ctrlKey)
+      ) {
+        event.preventDefault();
+        toggleSidebar();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [toggleSidebar]);
+
+  // We add a state so that we can do data-state="expanded" or "collapsed".
+  // This makes it easier to style the sidebar with Tailwind classes.
+  const state = open ? "expanded" : "collapsed";
+
+  const contextValue = useMemo<SidebarContextProps>(
+    () => ({
+      state,
+      open,
+      setOpen,
+      isMobile,
+      openMobile,
+      setOpenMobile,
+      toggleSidebar,
+    }),
+    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar],
+  );
+
+  return (
+    <SidebarContext.Provider value={contextValue}>
+      <TooltipProvider delayDuration={0}>
+        <div
+          data-slot="sidebar-wrapper"
+          style={
+            {
+              "--sidebar-width": SIDEBAR_WIDTH,
+              "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+              ...style,
+            } as React.CSSProperties
+          }
+          className={cn(
+            "group/sidebar-wrapper has-data-[variant=inset]:bg-bg flex min-h-svh w-full",
+            className,
+          )}
+          {...props}
+        >
+          {children}
+        </div>
+      </TooltipProvider>
+    </SidebarContext.Provider>
+  );
+};
+
+const Sidebar = ({
+  side = "left",
+  variant = "sidebar",
+  collapsible = "offcanvas",
+  className,
+  children,
+  ...props
+}: ComponentProps<"div"> & {
+  side?: "left" | "right";
+  variant?: "sidebar" | "floating" | "inset";
+  collapsible?: "offcanvas" | "icon" | "none";
+}) => {
+  const { isMobile, state, openMobile, setOpenMobile } = useSidebar();
+
+  if (collapsible === "none") {
+    return (
+      <div
+        data-slot="sidebar"
+        className={cn(
+          "bg-bg text-text-secondary flex h-full w-(--sidebar-width) flex-col",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+
+  if (isMobile) {
+    return (
+      <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
+        <SheetContent
+          data-sidebar="sidebar"
+          data-slot="sidebar"
+          data-mobile="true"
+          className="bg-bg text-text-secondary w-(--sidebar-width) p-0 [&>button]:hidden"
+          style={
+            {
+              "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
+            } as React.CSSProperties
+          }
+          side={side}
+        >
+          <SheetHeader className="sr-only">
+            <SheetTitle>Sidebar</SheetTitle>
+            <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+          </SheetHeader>
+          <div className="flex h-full w-full flex-col">{children}</div>
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
+  return (
+    <div
+      className="group peer text-text-secondary hidden md:block"
+      data-state={state}
+      data-collapsible={state === "collapsed" ? collapsible : ""}
+      data-variant={variant}
+      data-side={side}
+      data-slot="sidebar"
+    >
+      {/* This is what handles the sidebar gap on desktop */}
+      <div
+        data-slot="sidebar-gap"
+        className={cn(
+          "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
+          "group-data-[collapsible=offcanvas]:w-0",
+          "group-data-[side=right]:rotate-180",
+          variant === "floating" || variant === "inset" ?
+            "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]"
+          : "group-data-[collapsible=icon]:w-(--sidebar-width-icon)",
+        )}
+      />
+      <div
+        data-slot="sidebar-container"
+        className={cn(
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
+          side === "left" ?
+            "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
+          : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
+          // Adjust the padding for floating and inset variants.
+          variant === "floating" || variant === "inset" ?
+            "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
+          : "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l",
+          className,
+        )}
+        {...props}
+      >
+        <div
+          data-sidebar="sidebar"
+          data-slot="sidebar-inner"
+          className="bg-bg group-data-[variant=floating]:border-border flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm"
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const SidebarTrigger = ({
+  className,
+  onClick,
+  ...props
+}: ComponentProps<typeof Button>) => {
+  const { toggleSidebar } = useSidebar();
+
+  return (
+    <Button
+      data-sidebar="trigger"
+      data-slot="sidebar-trigger"
+      variant="ghost"
+      size="default" // Has "icon" as value from shadcn/ui
+      className={cn("text-muted-foreground size-7", className)}
+      onClick={(event) => {
+        onClick?.(event);
+        toggleSidebar();
+      }}
+      {...props}
+    >
+      <PanelLeftIcon />
+      <span className="sr-only">Toggle Sidebar</span>
+    </Button>
+  );
+};
+
+const SidebarRail = ({ className, ...props }: ComponentProps<"button">) => {
+  const { toggleSidebar } = useSidebar();
+
+  return (
+    <button
+      data-sidebar="rail"
+      data-slot="sidebar-rail"
+      aria-label="Toggle Sidebar"
+      tabIndex={-1}
+      onClick={toggleSidebar}
+      title="Toggle Sidebar"
+      className={cn(
+        "hover:after:bg-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex",
+        "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
+        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+        "hover:group-data-[collapsible=offcanvas]:bg-bg group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full",
+        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+
+const SidebarInset = ({ className, ...props }: ComponentProps<"main">) => {
+  return (
+    <main
+      data-slot="sidebar-inset"
+      className={cn(
+        "bg-background relative flex w-full flex-1 flex-col",
+        "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+
+const SidebarInput = ({
+  className,
+  ...props
+}: ComponentProps<typeof Input>) => {
+  return (
+    <Input
+      data-slot="sidebar-input"
+      data-sidebar="input"
+      className={cn("bg-background h-8 w-full shadow-none", className)}
+      {...props}
+    />
+  );
+};
+
+const SidebarHeader = ({ className, ...props }: ComponentProps<"div">) => {
+  return (
+    <div
+      data-slot="sidebar-header"
+      data-sidebar="header"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  );
+};
+
+const SidebarFooter = ({ className, ...props }: ComponentProps<"div">) => {
+  return (
+    <div
+      data-slot="sidebar-footer"
+      data-sidebar="footer"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  );
+};
+
+const SidebarSeparator = ({
+  className,
+  ...props
+}: ComponentProps<typeof Separator>) => {
+  return (
+    <Separator
+      data-slot="sidebar-separator"
+      data-sidebar="separator"
+      className={cn("bg-border mx-2 w-auto", className)}
+      {...props}
+    />
+  );
+};
+
+const SidebarContent = ({ className, ...props }: ComponentProps<"div">) => {
+  return (
+    <div
+      data-slot="sidebar-content"
+      data-sidebar="content"
+      className={cn(
+        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+
+const SidebarGroup = ({ className, ...props }: ComponentProps<"div">) => {
+  return (
+    <div
+      data-slot="sidebar-group"
+      data-sidebar="group"
+      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      {...props}
+    />
+  );
+};
+
+const SidebarGroupLabel = ({
+  className,
+  asChild = false,
+  ...props
+}: ComponentProps<"div"> & { asChild?: boolean }) => {
+  const Comp = asChild ? Slot : "div";
+
+  return (
+    <Comp
+      data-slot="sidebar-group-label"
+      data-sidebar="group-label"
+      className={cn(
+        "text-text-secondary/70 ring-border-tertiary flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+
+const SidebarGroupAction = ({
+  className,
+  asChild = false,
+  ...props
+}: ComponentProps<"button"> & { asChild?: boolean }) => {
+  const Comp = asChild ? Slot : "button";
+
+  return (
+    <Comp
+      data-slot="sidebar-group-action"
+      data-sidebar="group-action"
+      className={cn(
+        "text-text-secondary ring-border-tertiary hover:bg-bg-hover hover:text-text-secondary absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        // Increases the hit area of the button on mobile.
+        "after:absolute after:-inset-2 md:after:hidden",
+        "group-data-[collapsible=icon]:hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+
+const SidebarGroupContent = ({
+  className,
+  ...props
+}: ComponentProps<"div">) => {
+  return (
+    <div
+      data-slot="sidebar-group-content"
+      data-sidebar="group-content"
+      className={cn("w-full text-sm", className)}
+      {...props}
+    />
+  );
+};
+
+const SidebarMenu = ({ className, ...props }: ComponentProps<"ul">) => {
+  return (
+    <ul
+      data-slot="sidebar-menu"
+      data-sidebar="menu"
+      className={cn("flex w-full min-w-0 flex-col gap-1.5", className)}
+      {...props}
+    />
+  );
+};
+
+const SidebarMenuItem = ({ className, ...props }: ComponentProps<"li">) => {
+  return (
+    <li
+      data-slot="sidebar-menu-item"
+      data-sidebar="menu-item"
+      className={cn("group/menu-item relative", className)}
+      {...props}
+    />
+  );
+};
+
+const sidebarMenuButtonVariants = cva(
+  `peer/menu-button flex w-full items-center gap-2.5 overflow-hidden rounded-md p-2.5 text-left text-sm outline-hidden ring-border-tertiary transition-[width,height,padding,background-color]
+  hover:bg-bg-hover hover:text-text-secondary
+  focus-visible:ring-2
+  active:bg-bg-active active:text-text-secondary
+  disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50
+  group-has-data-[sidebar=menu-action]/menu-item:pr-8
+  data-[active=true]:bg-fill data-[active=true]:ring-border-shadow data-[active=true]:ring data-[active=true]:shadow-xs data-[active=true]:text-text-secondary
+  data-[state=open]:hover:bg-bg-hover data-[state=open]:hover:text-text-secondary
+  group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2!
+  [&>span:last-child]:truncate [&>svg]:size-3.5 [&>svg]:shrink-0`,
+  {
+    variants: {
+      variant: {
+        default: "hover:bg-bg-hover hover:text-text-secondary",
+        outline:
+          "bg-background shadow-[0_0_0_1px_hsl(var(--border))] hover:bg-bg-hover hover:text-text-secondary hover:shadow-[0_0_0_1px_hsl(var(--fill))]",
+      },
+      size: {
+        default: "h-7 text-sm",
+        sm: "h-7 text-xs",
+        lg: "h-10 text-sm group-data-[collapsible=icon]:p-0!",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+const SidebarMenuButton = ({
+  asChild = false,
+  isActive = false,
+  variant = "default",
+  size = "default",
+  tooltip,
+  className,
+  ...props
+}: ComponentProps<"button"> & {
+  asChild?: boolean;
+  isActive?: boolean;
+  tooltip?: string;
+} & VariantProps<typeof sidebarMenuButtonVariants>) => {
+  const Comp = asChild ? Slot : "button";
+  const { isMobile, state } = useSidebar();
+
+  const button = (
+    <Comp
+      data-slot="sidebar-menu-button"
+      data-sidebar="menu-button"
+      data-size={size}
+      data-active={isActive}
+      className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
+      {...props}
+    />
+  );
+
+  if (!tooltip) {
+    return button;
+  }
+
+  return (
+    <Tooltip
+      side="right"
+      tooltip={tooltip}
+      className={cn((state !== "collapsed" || isMobile) && "hidden")}
+    >
+      {button}
+    </Tooltip>
+  );
+};
+
+const SidebarMenuAction = ({
+  className,
+  asChild = false,
+  showOnHover = false,
+  ...props
+}: ComponentProps<"button"> & {
+  asChild?: boolean;
+  showOnHover?: boolean;
+}) => {
+  const Comp = asChild ? Slot : "button";
+
+  return (
+    <Comp
+      data-slot="sidebar-menu-action"
+      data-sidebar="menu-action"
+      className={cn(
+        "text-text-secondary ring-border-tertiary hover:bg-bg-hover hover:text-text-secondary peer-hover/menu-button:text-text-secondary absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        // Increases the hit area of the button on mobile.
+        "after:absolute after:-inset-2 md:after:hidden",
+        "peer-data-[size=sm]/menu-button:top-1",
+        "peer-data-[size=default]/menu-button:top-1.5",
+        "peer-data-[size=lg]/menu-button:top-2.5",
+        "group-data-[collapsible=icon]:hidden",
+        showOnHover &&
+          "peer-data-[active=true]/menu-button:text-text-secondary group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+
+const SidebarMenuBadge = ({ className, ...props }: ComponentProps<"div">) => {
+  return (
+    <div
+      data-slot="sidebar-menu-badge"
+      data-sidebar="menu-badge"
+      className={cn(
+        "text-text-secondary pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums select-none",
+        "peer-hover/menu-button:text-text-secondary peer-data-[active=true]/menu-button:text-text-secondary",
+        "peer-data-[size=sm]/menu-button:top-1",
+        "peer-data-[size=default]/menu-button:top-1.5",
+        "peer-data-[size=lg]/menu-button:top-2.5",
+        "group-data-[collapsible=icon]:hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+
+const SidebarMenuSkeleton = ({
+  className,
+  showIcon = false,
+  ...props
+}: ComponentProps<"div"> & {
+  showIcon?: boolean;
+}) => {
+  // Random width between 50 to 90%.
+  const width = useMemo(() => {
+    return `${Math.floor(Math.random() * 40) + 50}%`;
+  }, []);
+
+  return (
+    <div
+      data-slot="sidebar-menu-skeleton"
+      data-sidebar="menu-skeleton"
+      className={cn("flex h-8 items-center gap-2 rounded-md px-2", className)}
+      {...props}
+    >
+      {showIcon && (
+        <Skeleton
+          className="size-4 rounded-md"
+          data-sidebar="menu-skeleton-icon"
+        />
+      )}
+      <Skeleton
+        className="h-4 max-w-(--skeleton-width) flex-1"
+        data-sidebar="menu-skeleton-text"
+        style={
+          {
+            "--skeleton-width": width,
+          } as React.CSSProperties
+        }
+      />
+    </div>
+  );
+};
+
+const SidebarMenuSub = ({ className, ...props }: ComponentProps<"ul">) => {
+  return (
+    <ul
+      data-slot="sidebar-menu-sub"
+      data-sidebar="menu-sub"
+      className={cn(
+        "border-border mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l px-2.5 py-0.5",
+        "group-data-[collapsible=icon]:hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+
+const SidebarMenuSubItem = ({ className, ...props }: ComponentProps<"li">) => {
+  return (
+    <li
+      data-slot="sidebar-menu-sub-item"
+      data-sidebar="menu-sub-item"
+      className={cn("group/menu-sub-item relative", className)}
+      {...props}
+    />
+  );
+};
+
+const SidebarMenuSubButton = ({
+  asChild = false,
+  size = "md",
+  isActive = false,
+  className,
+  ...props
+}: ComponentProps<"a"> & {
+  asChild?: boolean;
+  size?: "sm" | "md";
+  isActive?: boolean;
+}) => {
+  const Comp = asChild ? Slot : "a";
+
+  return (
+    <Comp
+      data-slot="sidebar-menu-sub-button"
+      data-sidebar="menu-sub-button"
+      data-size={size}
+      data-active={isActive}
+      className={cn(
+        "text-text-secondary ring-border-tertiary hover:bg-bg-hover hover:text-text-secondary active:bg-fill [&>svg]:text-text-secondary flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+        "data-[active=true]:bg-fill data-[active=true]:text-text-secondary",
+        size === "sm" && "text-xs",
+        size === "md" && "text-sm",
+        "group-data-[collapsible=icon]:hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+
+export {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupAction,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInput,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSkeleton,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarSeparator,
+  SidebarTrigger,
+  useSidebar,
+};

--- a/src/components/interfaces/Sidebar/Sidebar.tsx
+++ b/src/components/interfaces/Sidebar/Sidebar.tsx
@@ -176,7 +176,7 @@ const Sidebar = ({
       <div
         data-slot="sidebar"
         className={cn(
-          "bg-bg text-text-secondary flex h-full w-(--sidebar-width) flex-col",
+          "bg-bg flex h-full w-(--sidebar-width) flex-col",
           className,
         )}
         {...props}
@@ -193,7 +193,7 @@ const Sidebar = ({
           data-sidebar="sidebar"
           data-slot="sidebar"
           data-mobile="true"
-          className="bg-bg text-text-secondary w-(--sidebar-width) p-0 [&>button]:hidden"
+          className="bg-bg w-(--sidebar-width) p-0 [&>button]:hidden"
           style={
             {
               "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
@@ -432,7 +432,7 @@ const SidebarGroupAction = ({
       data-slot="sidebar-group-action"
       data-sidebar="group-action"
       className={cn(
-        "text-text-secondary ring-border-tertiary hover:bg-bg-hover hover:text-text-secondary absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "ring-border-tertiary hover:bg-bg-hover absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
         // Increases the hit area of the button on mobile.
         "after:absolute after:-inset-2 md:after:hidden",
         "group-data-[collapsible=icon]:hidden",
@@ -481,21 +481,21 @@ const SidebarMenuItem = ({ className, ...props }: ComponentProps<"li">) => {
 
 const sidebarMenuButtonVariants = cva(
   `peer/menu-button flex w-full items-center gap-2.5 overflow-hidden rounded-md p-2.5 text-left text-sm outline-hidden ring-border-tertiary transition-[width,height,padding,background-color]
-  hover:bg-bg-hover hover:text-text-secondary
+  hover:bg-bg-hover
   focus-visible:ring-2 focus-visible:ring-border-focus
-  active:bg-bg-active active:text-text-secondary
+  active:bg-bg-active
   disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50
   group-has-data-[sidebar=menu-action]/menu-item:pr-8
   data-[active=true]:bg-fill data-[active=true]:ring-border-shadow data-[active=true]:ring data-[active=true]:shadow-xs data-[active=true]:text-text-secondary data-[active=true]:focus-visible:ring-2 data-[active=true]:focus-visible:ring-border-focus
-  data-[state=open]:hover:bg-bg-hover data-[state=open]:hover:text-text-secondary
+  data-[state=open]:hover:bg-bg-hover
   group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2!
   [&>span:last-child]:truncate [&>svg]:size-3.5 [&>svg]:shrink-0`,
   {
     variants: {
       variant: {
-        default: "hover:bg-bg-hover hover:text-text-secondary",
+        default: "hover:bg-bg-hover",
         outline:
-          "bg-background shadow-[0_0_0_1px_hsl(var(--border))] hover:bg-bg-hover hover:text-text-secondary hover:shadow-[0_0_0_1px_hsl(var(--fill))]",
+          "bg-background shadow-[0_0_0_1px_hsl(var(--border))] hover:bg-bg-hover hover:shadow-[0_0_0_1px_hsl(var(--fill))]",
       },
       size: {
         default: "h-7 text-sm",
@@ -568,7 +568,7 @@ const SidebarMenuAction = ({
       data-slot="sidebar-menu-action"
       data-sidebar="menu-action"
       className={cn(
-        "text-text-secondary ring-border-tertiary hover:bg-bg-hover hover:text-text-secondary peer-hover/menu-button:text-text-secondary absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "ring-border-tertiary hover:bg-bg-hover peer-hover/menu-button:text-text-secondary absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
         // Increases the hit area of the button on mobile.
         "after:absolute after:-inset-2 md:after:hidden",
         "peer-data-[size=sm]/menu-button:top-1",
@@ -590,7 +590,7 @@ const SidebarMenuBadge = ({ className, ...props }: ComponentProps<"div">) => {
       data-slot="sidebar-menu-badge"
       data-sidebar="menu-badge"
       className={cn(
-        "text-text-secondary pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums select-none",
+        "pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums select-none",
         "peer-hover/menu-button:text-text-secondary peer-data-[active=true]/menu-button:text-text-secondary",
         "peer-data-[size=sm]/menu-button:top-1",
         "peer-data-[size=default]/menu-button:top-1.5",
@@ -687,7 +687,7 @@ const SidebarMenuSubButton = ({
       data-size={size}
       data-active={isActive}
       className={cn(
-        "text-text-secondary ring-border-tertiary hover:bg-bg-hover hover:text-text-secondary active:bg-fill [&>svg]:text-text-secondary flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+        "ring-border-tertiary hover:bg-bg-hover active:bg-fill [&>svg]:text-text-secondary flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
         "data-[active=true]:bg-fill data-[active=true]:text-text-secondary",
         size === "sm" && "text-xs",
         size === "md" && "text-sm",

--- a/src/components/interfaces/Sidebar/Sidebar.tsx
+++ b/src/components/interfaces/Sidebar/Sidebar.tsx
@@ -271,7 +271,7 @@ const SidebarTrigger = ({
       data-sidebar="trigger"
       data-slot="sidebar-trigger"
       variant="ghost"
-      size="default" // Has "icon" as value from shadcn/ui
+      size="icon"
       className={cn("text-muted-foreground size-7", className)}
       onClick={(event) => {
         onClick?.(event);

--- a/src/components/interfaces/Sidebar/Sidebar.tsx
+++ b/src/components/interfaces/Sidebar/Sidebar.tsx
@@ -297,7 +297,7 @@ const SidebarRail = ({ className, ...props }: ComponentProps<"button">) => {
       onClick={toggleSidebar}
       title="Toggle Sidebar"
       className={cn(
-        "hover:after:bg-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex",
+        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[1px] hover:after:bg-black/20 sm:flex",
         "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
         "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
         "hover:group-data-[collapsible=offcanvas]:bg-bg group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full",

--- a/src/components/interfaces/Sidebar/Sidebar.tsx
+++ b/src/components/interfaces/Sidebar/Sidebar.tsx
@@ -482,11 +482,11 @@ const SidebarMenuItem = ({ className, ...props }: ComponentProps<"li">) => {
 const sidebarMenuButtonVariants = cva(
   `peer/menu-button flex w-full items-center gap-2.5 overflow-hidden rounded-md p-2.5 text-left text-sm outline-hidden ring-border-tertiary transition-[width,height,padding,background-color]
   hover:bg-bg-hover hover:text-text-secondary
-  focus-visible:ring-2
+  focus-visible:ring-2 focus-visible:ring-border-focus
   active:bg-bg-active active:text-text-secondary
   disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50
   group-has-data-[sidebar=menu-action]/menu-item:pr-8
-  data-[active=true]:bg-fill data-[active=true]:ring-border-shadow data-[active=true]:ring data-[active=true]:shadow-xs data-[active=true]:text-text-secondary
+  data-[active=true]:bg-fill data-[active=true]:ring-border-shadow data-[active=true]:ring data-[active=true]:shadow-xs data-[active=true]:text-text-secondary data-[active=true]:focus-visible:ring-2 data-[active=true]:focus-visible:ring-border-focus
   data-[state=open]:hover:bg-bg-hover data-[state=open]:hover:text-text-secondary
   group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2!
   [&>span:last-child]:truncate [&>svg]:size-3.5 [&>svg]:shrink-0`,

--- a/src/components/layouts/DashboardLayout.tsx
+++ b/src/components/layouts/DashboardLayout.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+import { Header } from "../interfaces/Header/Header";
+import { AppSidebar } from "../interfaces/Sidebar/AppSidebar";
+import { SidebarInset, SidebarProvider } from "../interfaces/Sidebar/Sidebar";
+
+interface Props {
+  children: ReactNode | ReactNode[];
+}
+
+export const DashboardLayout = ({ children }: Props) => {
+  return (
+    <div className="[--header-height:calc(--spacing(14))]">
+      <SidebarProvider className="flex flex-col">
+        <Header />
+        <div className="flex flex-1">
+          <AppSidebar className="top-(--header-height) !h-[calc(100svh-var(--header-height))]" />
+          <SidebarInset className="pt-(--header-height)">
+            {children}
+          </SidebarInset>
+        </div>
+      </SidebarProvider>
+    </div>
+  );
+};

--- a/src/components/ui/Avatar.tsx
+++ b/src/components/ui/Avatar.tsx
@@ -1,0 +1,3 @@
+import { Avatar } from "@stanfordspezi/spezi-web-design-system";
+
+export { Avatar };

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,3 @@
+import { Button } from "@stanfordspezi/spezi-web-design-system";
+
+export { Button };

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -11,7 +11,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-fill-brand inset-shadow-xs border border-border-brand inset-shadow-white/20 shadow-sm hover:bg-fill-brand-hover text-shadow-xs/5 text-text-brand-on-fill",
+          "bg-fill-brand inset-shadow-xs border border-border-brand inset-shadow-white/20 shadow-sm hover:bg-fill-brand-hover active:bg-fill-brand-active text-shadow-xs/5 text-text-brand-on-fill",
         destructive:
           "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -6,12 +6,12 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/utils/cn";
 
 const buttonVariants = cva(
-  "cursor-pointer inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "cursor-pointer inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:ring-border-focus focus-visible:ring-offset-2 focus-visible:ring-2 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
         default:
-          "bg-fill-brand inset-shadow-xs inset-shadow-white/20 shadow-xs hover:bg-fill-brand-hover text-shadow-xs/10 text-text-brand-on-fill",
+          "bg-fill-brand inset-shadow-xs border border-border-brand inset-shadow-white/20 shadow-sm hover:bg-fill-brand-hover text-shadow-xs/5 text-text-brand-on-fill",
         destructive:
           "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,3 +1,59 @@
-import { Button } from "@stanfordspezi/spezi-web-design-system";
+// Not building up the Spezi Web Design System, because I could not find a way to
+// override the default styles without using a bunch of !important flags
 
-export { Button };
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/utils/cn";
+
+const buttonVariants = cva(
+  "cursor-pointer inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-fill-brand inset-shadow-xs inset-shadow-white/20 shadow-xs hover:bg-fill-brand-hover text-shadow-xs/10 text-text-brand-on-fill",
+        destructive:
+          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "ring ring-border-shadow bg-surface inset-shadow-xs inset-shadow-white/20 shadow-xs hover:bg-black/2",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+        ghost: "hover:bg-bg-hover",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+const Button = ({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+  }) => {
+  const Comp = asChild ? Slot : "button";
+
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+};
+
+export { Button, buttonVariants };

--- a/src/components/ui/DropdownMenu.tsx
+++ b/src/components/ui/DropdownMenu.tsx
@@ -1,0 +1,61 @@
+import {
+  DropdownMenu,
+  DropdownMenuContent as _DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem as _DropdownMenuItem,
+  DropdownMenuLabel as _DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@stanfordspezi/spezi-web-design-system";
+import type { ComponentProps } from "react";
+import { cn } from "@/utils/cn";
+
+const DropdownMenuItem = ({
+  className,
+  ...props
+}: ComponentProps<typeof _DropdownMenuItem>) => {
+  return (
+    <_DropdownMenuItem
+      className={cn(
+        "focus:bg-surface-hover focus:text-foreground cursor-pointer rounded-sm!",
+        "[&_svg]:size-3.5!",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+
+const DropdownMenuLabel = ({
+  className,
+  ...props
+}: ComponentProps<typeof _DropdownMenuLabel>) => {
+  return (
+    <_DropdownMenuLabel
+      className={cn("text-text-tertiary! font-medium!", className)}
+      {...props}
+    />
+  );
+};
+
+const DropdownMenuContent = ({
+  className,
+  ...props
+}: ComponentProps<typeof _DropdownMenuContent>) => {
+  return (
+    <_DropdownMenuContent
+      className={cn("ring-border-shadow border-0 shadow-md ring", className)}
+      {...props}
+    />
+  );
+};
+
+export {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+};

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,0 +1,3 @@
+import { Input } from "@stanfordspezi/spezi-web-design-system";
+
+export { Input };

--- a/src/components/ui/Separator.tsx
+++ b/src/components/ui/Separator.tsx
@@ -1,0 +1,3 @@
+import { Separator } from "@stanfordspezi/spezi-web-design-system";
+
+export { Separator };

--- a/src/components/ui/Sheet.tsx
+++ b/src/components/ui/Sheet.tsx
@@ -60,7 +60,7 @@ const SheetContent = ({
       {...props}
     >
       {children}
-      <SheetPrimitive.Close className="ring-offset-surface focus:ring-border-tertiary data-[state=open]:bg-fill-inverted absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+      <SheetPrimitive.Close className="ring-offset-surface focus:ring-border-focus data-[state=open]:bg-fill-inverted absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
         <XIcon className="size-4" />
         <span className="sr-only">Close</span>
       </SheetPrimitive.Close>

--- a/src/components/ui/Sheet.tsx
+++ b/src/components/ui/Sheet.tsx
@@ -1,0 +1,118 @@
+import * as SheetPrimitive from "@radix-ui/react-dialog";
+import { XIcon } from "lucide-react";
+import type { ComponentProps } from "react";
+import { cn } from "@/utils/cn";
+
+const Sheet = (props: ComponentProps<typeof SheetPrimitive.Root>) => (
+  <SheetPrimitive.Root data-slot="sheet" {...props} />
+);
+
+const SheetTrigger = (props: ComponentProps<typeof SheetPrimitive.Trigger>) => (
+  <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+);
+
+const SheetClose = (props: ComponentProps<typeof SheetPrimitive.Close>) => (
+  <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+);
+
+const SheetPortal = (props: ComponentProps<typeof SheetPrimitive.Portal>) => (
+  <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+);
+
+const SheetOverlay = ({
+  className,
+  ...props
+}: ComponentProps<typeof SheetPrimitive.Overlay>) => (
+  <SheetPrimitive.Overlay
+    data-slot="sheet-overlay"
+    className={cn(
+      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+      className,
+    )}
+    {...props}
+  />
+);
+
+const SheetContent = ({
+  className,
+  children,
+  side = "right",
+  ...props
+}: ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left";
+}) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+      data-slot="sheet-content"
+      className={cn(
+        "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 rounded-lg shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+        side === "right" &&
+          "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-2 right-2 w-3/4 border-l sm:max-w-sm",
+        side === "left" &&
+          "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-2 left-2 w-3/4 border-r sm:max-w-sm",
+        side === "top" &&
+          "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-2 top-2 border-b",
+        side === "bottom" &&
+          "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-2 bottom-2 border-t",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+        <XIcon className="size-4" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+    </SheetPrimitive.Content>
+  </SheetPortal>
+);
+
+const SheetHeader = ({ className, ...props }: ComponentProps<"div">) => (
+  <div
+    data-slot="sheet-header"
+    className={cn("flex flex-col gap-1.5 p-4", className)}
+    {...props}
+  />
+);
+
+const SheetFooter = ({ className, ...props }: ComponentProps<"div">) => (
+  <div
+    data-slot="sheet-footer"
+    className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+    {...props}
+  />
+);
+
+const SheetTitle = ({
+  className,
+  ...props
+}: ComponentProps<typeof SheetPrimitive.Title>) => (
+  <SheetPrimitive.Title
+    data-slot="sheet-title"
+    className={cn("text-foreground font-semibold", className)}
+    {...props}
+  />
+);
+
+const SheetDescription = ({
+  className,
+  ...props
+}: ComponentProps<typeof SheetPrimitive.Description>) => (
+  <SheetPrimitive.Description
+    data-slot="sheet-description"
+    className={cn("text-muted-foreground text-sm", className)}
+    {...props}
+  />
+);
+
+export {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+};

--- a/src/components/ui/Sheet.tsx
+++ b/src/components/ui/Sheet.tsx
@@ -46,7 +46,7 @@ const SheetContent = ({
     <SheetPrimitive.Content
       data-slot="sheet-content"
       className={cn(
-        "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 rounded-lg shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+        "bg-surface data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 rounded-lg shadow-lg transition ease-in-out data-[state=closed]:duration-200 data-[state=open]:duration-500",
         side === "right" &&
           "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-2 right-2 w-3/4 border-l sm:max-w-sm",
         side === "left" &&
@@ -60,7 +60,7 @@ const SheetContent = ({
       {...props}
     >
       {children}
-      <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+      <SheetPrimitive.Close className="ring-offset-surface focus:ring-border-tertiary data-[state=open]:bg-fill-inverted absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
         <XIcon className="size-4" />
         <span className="sr-only">Close</span>
       </SheetPrimitive.Close>
@@ -90,7 +90,7 @@ const SheetTitle = ({
 }: ComponentProps<typeof SheetPrimitive.Title>) => (
   <SheetPrimitive.Title
     data-slot="sheet-title"
-    className={cn("text-foreground font-semibold", className)}
+    className={cn("text-text font-semibold", className)}
     {...props}
   />
 );
@@ -101,7 +101,7 @@ const SheetDescription = ({
 }: ComponentProps<typeof SheetPrimitive.Description>) => (
   <SheetPrimitive.Description
     data-slot="sheet-description"
-    className={cn("text-muted-foreground text-sm", className)}
+    className={cn("text-tertiary text-sm", className)}
     {...props}
   />
 );

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -1,0 +1,3 @@
+import { Skeleton } from "@stanfordspezi/spezi-web-design-system";
+
+export { Skeleton };

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -1,0 +1,8 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@stanfordspezi/spezi-web-design-system";
+
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -1,8 +1,22 @@
 import {
-  Tooltip,
+  Tooltip as _Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from "@stanfordspezi/spezi-web-design-system";
+import type { ComponentProps } from "react";
+import { cn } from "@/utils/cn";
+
+const Tooltip = ({ className, ...props }: ComponentProps<typeof _Tooltip>) => {
+  return (
+    <_Tooltip
+      className={cn(
+        "bg-fill-inverted! text-text-inverted-on-fill border-none px-1! py-0.5! text-xs shadow-md",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
 
 export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,7 +11,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { routeTree } from "./routeTree.gen";
 
-import "./index.css";
+import "./styles/index.css";
 
 const router = createRouter({
   basepath: "/spezi-web-study-platform", // This is necessary for GitHub Pages

--- a/src/routes/~(dashboard)/~$team/~$study/~configuration.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~configuration.tsx
@@ -9,7 +9,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 const StudyConfigurationRoute = () => {
-  return <div>Study Configuration Route</div>;
+  return <div className="flex-center size-full">Study Configuration Route</div>;
 };
 
 export const Route = createFileRoute("/(dashboard)/$team/$study/configuration")(

--- a/src/routes/~(dashboard)/~$team/~$study/~index.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~index.tsx
@@ -6,8 +6,8 @@
 // SPDX-License-Identifier: MIT
 //
 
-import { Button } from "@stanfordspezi/spezi-web-design-system";
 import { createFileRoute } from "@tanstack/react-router";
+import { Button } from "@/components/ui/Button";
 
 const StudyHomeRoute = () => {
   const { team, study } = Route.useParams();
@@ -17,7 +17,9 @@ const StudyHomeRoute = () => {
         <p>Study Home Route</p>
         <p>Team: {team}</p>
         <p>Study: {study}</p>
-        <Button>Click me</Button>
+        <div className="space-x-4">
+          <Button>Click me</Button>
+        </div>
       </div>
     </div>
   );

--- a/src/routes/~(dashboard)/~$team/~$study/~index.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~index.tsx
@@ -12,11 +12,13 @@ import { createFileRoute } from "@tanstack/react-router";
 const StudyHomeRoute = () => {
   const { team, study } = Route.useParams();
   return (
-    <div>
-      <p>Study Home Route</p>
-      <p>Team: {team}</p>
-      <p>Study: {study}</p>
-      <Button>Click me</Button>
+    <div className="flex-center size-full">
+      <div>
+        <p>Study Home Route</p>
+        <p>Team: {team}</p>
+        <p>Study: {study}</p>
+        <Button>Click me</Button>
+      </div>
     </div>
   );
 };

--- a/src/routes/~(dashboard)/~$team/~$study/~index.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~index.tsx
@@ -14,12 +14,10 @@ const StudyHomeRoute = () => {
   return (
     <div className="flex-center size-full">
       <div>
-        <p>Study Home Route</p>
-        <p>Team: {team}</p>
+        <p className="text-text">Study Home Route</p>
+        <p className="text-text-secondary">Team: {team}</p>
         <p>Study: {study}</p>
-        <div className="space-x-4">
-          <Button>Click me</Button>
-        </div>
+        <Button>Click me</Button>
       </div>
     </div>
   );

--- a/src/routes/~(dashboard)/~$team/~$study/~layout.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~layout.tsx
@@ -6,33 +6,17 @@
 // SPDX-License-Identifier: MIT
 //
 
-import { createFileRoute, Link, Outlet } from "@tanstack/react-router";
+import { createFileRoute, Outlet } from "@tanstack/react-router";
+import { DashboardLayout } from "@/components/layouts/DashboardLayout";
 
-const DashboardLayout = () => {
-  const params = Route.useParams();
+const DashboardLayoutRoute = () => {
   return (
-    <div className="flex">
-      <div className="flex w-1/4 flex-col gap-4 bg-gray-100 p-4">
-        <Link to="/$team/$study" params={params}>
-          Home
-        </Link>
-        <Link to="/$team/$study/configuration" params={params}>
-          Configuration
-        </Link>
-        <Link to="/$team/$study/participants" params={params}>
-          Participants
-        </Link>
-        <Link to="/$team/$study/results" params={params}>
-          Results
-        </Link>
-      </div>
-      <div className="grid w-3/4 place-items-center">
-        <Outlet />
-      </div>
-    </div>
+    <DashboardLayout>
+      <Outlet />
+    </DashboardLayout>
   );
 };
 
 export const Route = createFileRoute("/(dashboard)/$team/$study")({
-  component: DashboardLayout,
+  component: DashboardLayoutRoute,
 });

--- a/src/routes/~(dashboard)/~$team/~$study/~participants.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~participants.tsx
@@ -9,7 +9,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 const StudyParticipantsRoute = () => {
-  return <div>Study Participants Route</div>;
+  return <div className="flex-center size-full">Study Participants Route</div>;
 };
 
 export const Route = createFileRoute("/(dashboard)/$team/$study/participants")({

--- a/src/routes/~(dashboard)/~$team/~$study/~results.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~results.tsx
@@ -9,7 +9,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 const StudyResultsRoute = () => {
-  return <div>Study Results Route</div>;
+  return <div className="flex-center size-full">Study Results Route</div>;
 };
 
 export const Route = createFileRoute("/(dashboard)/$team/$study/results")({

--- a/src/routes/~__root.tsx
+++ b/src/routes/~__root.tsx
@@ -6,28 +6,19 @@
 // SPDX-License-Identifier: MIT
 //
 
-import { SpeziProvider } from "@stanfordspezi/spezi-web-design-system";
 import {
   createRootRouteWithContext,
   HeadContent,
-  Link,
   Outlet,
 } from "@tanstack/react-router";
-import type { ComponentProps } from "react";
-
-const routerProps: ComponentProps<typeof SpeziProvider>["router"] = {
-  Link: ({ href, ...props }) => <Link to={href} {...props} />,
-};
 
 const RootComponent = () => {
   return (
     <>
       <HeadContent />
-      <SpeziProvider router={routerProps}>
-        <div className="grid h-svh grid-rows-[1fr]">
-          <Outlet />
-        </div>
-      </SpeziProvider>
+      <div className="grid h-svh grid-rows-[1fr]">
+        <Outlet />
+      </div>
     </>
   );
 };

--- a/src/styles/color.css
+++ b/src/styles/color.css
@@ -1,0 +1,186 @@
+/* Extending the primitive color tokens with the help of https://fullwindcss.com */
+:root {
+  --color-zinc-10: oklch(99.7% 0 none);
+  --color-zinc-50: oklch(98.51% 0 none);
+  --color-zinc-100: oklch(96.74% 0 287.3deg);
+  --color-zinc-150: oklch(94.36% 0 286.82deg);
+  --color-zinc-200: oklch(91.97% 0 286.61deg);
+  --color-zinc-250: oklch(89.54% 0 286.55deg);
+  --color-zinc-300: oklch(87.11% 0.01 286.49deg);
+  --color-zinc-350: oklch(79.15% 0.01 286.4deg);
+  --color-zinc-400: oklch(71.18% 0.01 286.14deg);
+  --color-zinc-450: oklch(63.17% 0.01 286.09deg);
+  --color-zinc-500: oklch(55.17% 0.01 285.99deg);
+  --color-zinc-550: oklch(49.68% 0.01 285.93deg);
+  --color-zinc-600: oklch(44.19% 0.01 285.82deg);
+  --color-zinc-650: oklch(40.61% 0.01 285.83deg);
+  --color-zinc-700: oklch(37.03% 0.01 285.84deg);
+  --color-zinc-750: oklch(32.21% 0.01 285.99deg);
+  --color-zinc-800: oklch(27.39% 0.01 286.1deg);
+  --color-zinc-850: oklch(24.21% 0.01 286.04deg);
+  --color-zinc-900: oklch(21.03% 0.01 285.93deg);
+  --color-zinc-950: oklch(14.08% 0 285.86deg);
+  --color-zinc-990: oklch(8.23% 0 285.86deg);
+
+  --color-brand-10: oklch(99.64% 0 155.22);
+  --color-brand-50: oklch(97.13% 0.019 167.94);
+  --color-brand-100: oklch(94.37% 0.038 164.87);
+  --color-brand-200: oklch(88.13% 0.085 162.99);
+  --color-brand-300: oklch(81.31% 0.132 160.4);
+  --color-brand-400: oklch(73.28% 0.163 156.54);
+  --color-brand-450: oklch(69.33% 0.151 156.68);
+  --color-brand-500: oklch(64.33% 0.141 156.81);
+  --color-brand-600: oklch(59.45% 0.13 156.82);
+  --color-brand-700: oklch(54.46% 0.118 156.84);
+  --color-brand-800: oklch(46.94% 0.1 157.56);
+  --color-brand-900: oklch(37.78% 0.078 157.64);
+  --color-brand-950: oklch(29.82% 0.058 158.28);
+
+  --color-green-10: oklch(99.64% 0 155.22);
+  --color-yellow-10: oklch(99.75% 0.01 100);
+  --color-red-10: oklch(99.41% 0 18.09);
+}
+
+/*
+    Semantic color tokens, inspired by https://polaris-react.shopify.com/tokens/color
+    color-[concept?]-[element]-[role?]-[prominence?]-[state?]
+    Concept: nav, sidebar
+    Element: bg, surface, fill, border, text, icon
+    Role: default, brand, info, success, caution, warning, critical, magic, emphasis, transparent, inverse
+    Prominence: primary, secondary, tertiary
+    State: hover, active, selected, disabled, focus
+*/
+:root {
+  /* Background */
+  --bg: var(--color-zinc-50);
+  --bg-hover: var(--color-zinc-100);
+  --bg-active: var(--color-zinc-200);
+  --bg-secondary: var(--color-zinc-150);
+  --bg-secondary-hover: var(--color-zinc-200);
+  --bg-tertiary: var(--color-zinc-250);
+  --bg-tertiary-hover: var(--color-zinc-300);
+
+  /* Surface */
+  --surface: var(--color-zinc-10);
+  --surface-hover: var(--color-zinc-100);
+
+  /* Fill */
+  --fill: var(--color-zinc-10);
+  --fill-brand: var(--color-brand-500);
+  --fill-brand-hover: var(--color-brand-450);
+  --fill-inverted: var(--color-zinc-900);
+  --fill-success: var(--color-green-700);
+  --fill-warning: var(--color-yellow-500);
+  --fill-critical: var(--color-red-600);
+
+  /* Border */
+  --border: var(--color-zinc-200);
+  --border-secondary: var(--color-zinc-300);
+  --border-tertiary: var(--color-zinc-400);
+  --border-focus: oklch(50.4% 0.199 259);
+  /* The border color to be used on elements with a shadow. If we were to use a regular shadow, it would look muddy.
+  See https://x.com/steveschoger/status/1695139153753604384 for a visual example */
+  --border-shadow: oklch(0% 0 0 / 5%);
+
+  /* Text */
+  --text: var(--color-zinc-700);
+  --text-secondary: var(--color-zinc-600);
+  --text-tertiary: var(--color-zinc-500);
+  --text-on-fill: var(--color-zinc-900);
+  --text-brand-on-fill: var(--color-brand-10);
+  --text-inverted-on-fill: var(--color-zinc-100);
+  --text-success-on-fill: var(--color-green-10);
+  --text-warning-on-fill: var(--color-yellow-10);
+  --text-critical-on-fill: var(--color-red-10);
+
+  /* Icon */
+  --icon: var(--color-zinc-900);
+  --icon-secondary: var(--color-zinc-600);
+  --icon-tertiary: var(--color-zinc-500);
+}
+
+/* Spezi Web Design System */
+:root {
+  --color-surface: var(--bg); /* "rgb(250 250 249)", */
+  --color-surface-primary: var(--bg); /* "rgb(255 255 255)", */
+  --color-foreground: var(--text); /* "rgb(9 4 4)", */
+  --color-card: var(--surface); /* "rgb(255 255 255)", */
+  --color-card-foreground: var(--text); /* "rgb(9 4 4)", */
+  --color-popover: var(--surface); /* "rgb(255 255 255)", */
+  --color-popover-foreground: var(--text); /* "rgb(9 4 4)", */
+  --color-primary: var(--fill-brand); /* "rgb(62 176 85)", */
+  --color-primary-foreground: var(
+    --text-brand-on-fill
+  ); /* "rgb(243 243 243)", */
+  --color-secondary: var(--fill-inverted); /* "rgb(242 240 240)", */
+  --color-secondary-foreground: var(
+    --text-inverted-on-fill
+  ); /* "rgb(30 15 15)", */
+  --color-muted: var(--bg-secondary); /* "rgb(242 240 240)", */
+  --color-muted-foreground: var(--text-secondary); /* "rgb(159 159 159)", */
+  --color-accent: var(--fill-brand); /* "rgb(242 240 240)", */
+  --color-accent-foreground: var(--text-brand-on-fill); /* "rgb(30 15 15)", */
+  /* --color-border: var(--border); "rgb(232 215 221)", */
+  --color-input: var(--border); /* "rgb(232 215 221)", */
+  --color-destructive: var(--fill-critical); /* "rgb(222 65 38)", */
+  --color-destructive-foreground: var(
+    --text-critical-on-fill
+  ); /* "rgb(243 243 243)", */
+  --color-success: var(--fill-success); /* "rgb(34 197 94)", */
+  --color-success-foreground: var(
+    --text-success-on-fill
+  ); /* "rgb(243 243 243)", */
+  --color-warning: var(--fill-warning); /* "rgb(252 211 3)", */
+  --color-warning-dark: var(--fill-warning); /* "rgb(153 101 21)", */
+  --color-warning-foreground: var(--text-warning-on-fill); /* "rgb(9 4 4)", */
+  --color-ring: var(--border-tertiary); /* "rgb(62 176 85)", */
+}
+
+@theme inline {
+  /* Background */
+  --color-bg: var(--bg);
+  --color-bg-hover: var(--bg-hover);
+  --color-bg-secondary: var(--bg-secondary);
+  --color-bg-secondary-hover: var(--bg-secondary-hover);
+  --color-bg-tertiary: var(--bg-tertiary);
+  --color-bg-tertiary-hover: var(--bg-tertiary-hover);
+
+  /* Surface */
+  --color-surface: var(--surface);
+  --color-surface-hover: var(--surface-hover);
+
+  /* Fill */
+  --color-fill: var(--fill);
+  --color-fill-brand: var(--fill-brand);
+  --color-fill-brand-hover: var(--fill-brand-hover);
+  --color-fill-inverted: var(--fill-inverted);
+  --color-fill-success: var(--fill-success);
+  --color-fill-warning: var(--fill-warning);
+  --color-fill-critical: var(--fill-critical);
+
+  /* Border */
+  --color-border: var(--border);
+  --color-border-secondary: var(--border-secondary);
+  --color-border-tertiary: var(--border-tertiary);
+  --color-border-focus: var(--border-focus);
+  --color-border-shadow: var(--border-shadow);
+
+  /* Text */
+  --color-text: var(--text);
+  --color-text-secondary: var(--text-secondary);
+  --color-text-tertiary: var(--text-tertiary);
+  --color-text-brand-on-fill: var(--text-brand-on-fill);
+  --color-text-on-fill: var(--text-on-fill);
+  --color-text-inverted-on-fill: var(--text-inverted-on-fill);
+  --color-text-success-on-fill: var(--text-success-on-fill);
+  --color-text-warning-on-fill: var(--text-warning-on-fill);
+  --color-text-critical-on-fill: var(--text-critical-on-fill);
+
+  /* Icon */
+  --color-icon: var(--icon);
+  --color-icon-secondary: var(--icon-secondary);
+  --color-icon-tertiary: var(--icon-tertiary);
+
+  /* The Spezi Web Design System theme definitions are already
+  loaded by spezi-web-design-system/tailwind.css in index.css */
+}

--- a/src/styles/color.css
+++ b/src/styles/color.css
@@ -77,10 +77,11 @@
   --border: var(--color-zinc-200);
   --border-secondary: var(--color-zinc-300);
   --border-tertiary: var(--color-zinc-400);
-  --border-focus: oklch(50.4% 0.199 259);
+  --border-focus: var(--color-brand-500);
   /* The border color to be used on elements with a shadow. If we were to use a regular shadow, it would look muddy.
   See https://x.com/steveschoger/status/1695139153753604384 for a visual example */
   --border-shadow: oklch(0% 0 0 / 5%);
+  --border-brand: var(--color-brand-600);
 
   /* Text */
   --text: var(--color-zinc-700);
@@ -164,6 +165,7 @@
   --color-border-tertiary: var(--border-tertiary);
   --color-border-focus: var(--border-focus);
   --color-border-shadow: var(--border-shadow);
+  --color-border-brand: var(--border-brand);
 
   /* Text */
   --color-text: var(--text);

--- a/src/styles/color.css
+++ b/src/styles/color.css
@@ -2,25 +2,25 @@
 :root {
   --color-zinc-10: oklch(99.7% 0 none);
   --color-zinc-50: oklch(98.51% 0 none);
-  --color-zinc-100: oklch(96.74% 0 287.3deg);
-  --color-zinc-150: oklch(94.36% 0 286.82deg);
-  --color-zinc-200: oklch(91.97% 0 286.61deg);
-  --color-zinc-250: oklch(89.54% 0 286.55deg);
-  --color-zinc-300: oklch(87.11% 0.01 286.49deg);
-  --color-zinc-350: oklch(79.15% 0.01 286.4deg);
-  --color-zinc-400: oklch(71.18% 0.01 286.14deg);
-  --color-zinc-450: oklch(63.17% 0.01 286.09deg);
-  --color-zinc-500: oklch(55.17% 0.01 285.99deg);
-  --color-zinc-550: oklch(49.68% 0.01 285.93deg);
-  --color-zinc-600: oklch(44.19% 0.01 285.82deg);
-  --color-zinc-650: oklch(40.61% 0.01 285.83deg);
-  --color-zinc-700: oklch(37.03% 0.01 285.84deg);
-  --color-zinc-750: oklch(32.21% 0.01 285.99deg);
-  --color-zinc-800: oklch(27.39% 0.01 286.1deg);
-  --color-zinc-850: oklch(24.21% 0.01 286.04deg);
-  --color-zinc-900: oklch(21.03% 0.01 285.93deg);
-  --color-zinc-950: oklch(14.08% 0 285.86deg);
-  --color-zinc-990: oklch(8.23% 0 285.86deg);
+  --color-zinc-100: oklch(96.74% 0 287.3);
+  --color-zinc-150: oklch(94.36% 0 286.82);
+  --color-zinc-200: oklch(91.97% 0 286.61);
+  --color-zinc-250: oklch(89.54% 0 286.55);
+  --color-zinc-300: oklch(87.11% 0.01 286.49);
+  --color-zinc-350: oklch(79.15% 0.01 286.4);
+  --color-zinc-400: oklch(71.18% 0.01 286.14);
+  --color-zinc-450: oklch(63.17% 0.01 286.09);
+  --color-zinc-500: oklch(55.17% 0.01 285.99);
+  --color-zinc-550: oklch(49.68% 0.01 285.93);
+  --color-zinc-600: oklch(44.19% 0.01 285.82);
+  --color-zinc-650: oklch(40.61% 0.01 285.83);
+  --color-zinc-700: oklch(37.03% 0.01 285.84);
+  --color-zinc-750: oklch(32.21% 0.01 285.99);
+  --color-zinc-800: oklch(27.39% 0.01 286.1);
+  --color-zinc-850: oklch(24.21% 0.01 286.04);
+  --color-zinc-900: oklch(21.03% 0.01 285.93);
+  --color-zinc-950: oklch(14.08% 0 285.86);
+  --color-zinc-990: oklch(8.23% 0 285.86);
 
   --color-brand-10: oklch(99.64% 0 155.22);
   --color-brand-50: oklch(97.13% 0.019 167.94);
@@ -84,8 +84,8 @@
   --border-brand: var(--color-brand-600);
 
   /* Text */
-  --text: var(--color-zinc-700);
-  --text-secondary: var(--color-zinc-600);
+  --text: var(--color-zinc-900);
+  --text-secondary: var(--color-zinc-700);
   --text-tertiary: var(--color-zinc-500);
   --text-on-fill: var(--color-zinc-900);
   --text-brand-on-fill: var(--color-brand-10);
@@ -104,11 +104,11 @@
 :root {
   --color-surface: var(--bg); /* "rgb(250 250 249)", */
   --color-surface-primary: var(--bg); /* "rgb(255 255 255)", */
-  --color-foreground: var(--text); /* "rgb(9 4 4)", */
+  --color-foreground: var(--text-secondary); /* "rgb(9 4 4)", */
   --color-card: var(--surface); /* "rgb(255 255 255)", */
-  --color-card-foreground: var(--text); /* "rgb(9 4 4)", */
+  --color-card-foreground: var(--text-secondary); /* "rgb(9 4 4)", */
   --color-popover: var(--surface); /* "rgb(255 255 255)", */
-  --color-popover-foreground: var(--text); /* "rgb(9 4 4)", */
+  --color-popover-foreground: var(--text-secondary); /* "rgb(9 4 4)", */
   --color-primary: var(--fill-brand); /* "rgb(62 176 85)", */
   --color-primary-foreground: var(
     --text-brand-on-fill
@@ -141,6 +141,7 @@
   /* Background */
   --color-bg: var(--bg);
   --color-bg-hover: var(--bg-hover);
+  --color-bg-active: var(--bg-active);
   --color-bg-secondary: var(--bg-secondary);
   --color-bg-secondary-hover: var(--bg-secondary-hover);
   --color-bg-tertiary: var(--bg-tertiary);

--- a/src/styles/color.css
+++ b/src/styles/color.css
@@ -68,6 +68,7 @@
   --fill: var(--color-zinc-10);
   --fill-brand: var(--color-brand-500);
   --fill-brand-hover: var(--color-brand-450);
+  --fill-brand-active: var(--color-brand-400);
   --fill-inverted: var(--color-zinc-900);
   --fill-success: var(--color-green-700);
   --fill-warning: var(--color-yellow-500);
@@ -155,6 +156,7 @@
   --color-fill: var(--fill);
   --color-fill-brand: var(--fill-brand);
   --color-fill-brand-hover: var(--fill-brand-hover);
+  --color-fill-brand-active: var(--fill-brand-active);
   --color-fill-inverted: var(--fill-inverted);
   --color-fill-success: var(--fill-success);
   --color-fill-warning: var(--fill-warning);

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -12,7 +12,7 @@ SPDX-License-Identifier: MIT
 @import "@stanfordspezi/spezi-web-design-system/base.css";
 @import "./color.css";
 
-@source "../node_modules/@stanfordspezi/spezi-web-design-system/dist/**/*.js";
+@source "../../node_modules/@stanfordspezi/spezi-web-design-system/dist/**/*.js";
 
 :root {
   -webkit-font-smoothing: antialiased;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -10,5 +10,12 @@ SPDX-License-Identifier: MIT
 
 @import "@stanfordspezi/spezi-web-design-system/tailwind.css";
 @import "@stanfordspezi/spezi-web-design-system/base.css";
+@import "./color.css";
 
-@source '../node_modules/@stanfordspezi/spezi-web-design-system/dist/**/*.js';
+@source "../node_modules/@stanfordspezi/spezi-web-design-system/dist/**/*.js";
+
+:root {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,0 +1,11 @@
+import { cn as _cn } from "@stanfordspezi/spezi-web-design-system";
+import { twMerge } from "tailwind-merge";
+
+/**
+ * Utility function for combining class names with conditional logic.
+ * Builds upon the `cn` function from the Spezi Design System.
+ * This function also merges Tailwind CSS classes without style conflicts.
+ */
+export const cn = (...inputs: Parameters<typeof _cn>) => {
+  return twMerge(_cn(...inputs));
+};

--- a/src/utils/useIsMobile.ts
+++ b/src/utils/useIsMobile.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+
+const MOBILE_BREAKPOINT = 768;
+
+/**
+ * Custom React hook that determines if the current viewport width is considered "mobile"
+ * based on the `MOBILE_BREAKPOINT` constant.
+ *
+ * @example
+ * const isMobile = useIsMobile();
+ * if (isMobile) {
+ *   // Render mobile-specific UI
+ * }
+ */
+export const useIsMobile = () => {
+  const [isMobile, setIsMobile] = useState<boolean | undefined>(undefined);
+
+  useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const onChange = () => {
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    };
+    mql.addEventListener("change", onChange);
+    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
+
+  return !!isMobile;
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,7 +41,7 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "."),
+      "@": path.resolve(__dirname, "./src"),
     },
   },
 });


### PR DESCRIPTION
# Add components and styling to the dashboard layout

![edited_screenshot](https://github.com/user-attachments/assets/05c8b8f2-ff41-40ad-bdb6-f7e47d3625df)

## :recycle: Current situation & Problem
The dashboard layout is currently not styled and missing components from the wireframe.

## :gear: Release Notes
* Added a new `Header` component with various subcomponents to provide users a way to navigate between different teams and studies and manage their account and notifications.
* Introduced a new `AppSidebar` component with sidebar menu items that allow users to navigate between different pages inside a single study. The sidebar also contains secondary actions such as opening documentation or giving feedback.
* Added a project specific design system with primitive and semantic color tokens.
* Integrated and partially customized various Spezi Design System Components.

## :books: Documentation
This PR focuses on the desktop version only. The PR was already quite big, so the mobile specific implementation will follow in a separate PR. #20 

### Repo Structure
Added a new `components` folder to `src` that contains somewhat reusable components. I took inspiration from Supabase ([Supabase Studio Components README](https://github.com/supabase/supabase/blob/master/apps/studio/components/README.md)) to organize the components efficiently. In short:
- For components that declare the general structure and layout of a page:
  - `/components/layouts/xxx`
- For components that are tightly coupled to a specific interface:
  - `/components/interfaces/xxx`
- For components that are meant to be reusable across multiple pages:
  - `/components/ui/xxx`

### Dashboard Layout
For the dashboard layout, I chose a design that features a full width top header and an app sidebar. This layout makes it clear that all actions in the top header are not related to study specific changes (e.g. changing your team, notifications, user account). The secondary user actions (i.e. feedback, help, sidebar collapse) are placed in the bottom left. This layout follows the [F-shaped scanning pattern](https://www.nngroup.com/articles/f-shaped-pattern-reading-web-content-discovered/).

### Design System
The basic ui components are taken - where available - from the [spezi-web-design-system](https://github.com/StanfordSpezi/spezi-web-design-system). I adapted the styling for some of the components to better match the visual identity of this particular project. Had to use a few `!important` statements to get the styles to work.

For the color system, I have chosen an approach similar to that of the [Shopify Polaris](https://polaris-react.shopify.com/design/colors) design system. In my opinion, their choice of semantic color tokens is very logical, extensive and well-documented. Though it is certainly more complex than the default `shadcn/ui` styles, I think that it'll help contributors understand which colors to use under which circumstances. From my experience with `shadcn/ui`, I often have to resort to undocumented one-off color choices for a lot of edge cases that are not covered by the default color options.

I will also write some more extensive documentation on the reasoning behind the design system. I will also add a color reference (similar to the [Shopify one](https://polaris-react.shopify.com/tokens/color)) that allows contributors to get a really good understanding of the meaning of the different semantic color tokens. #19 

## :white_check_mark: Testing
Added no new tests, the existing tests should suffice. This PR was focused on styling changes.

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).