### PR TITLE
Closes #19: Add documentation for color and styling

### DIFF
--- a/.github/instructions/reference.instructions.md
+++ b/.github/instructions/reference.instructions.md
@@ -1,0 +1,19 @@
+---
+applyTo: "docs/reference/**"
+---
+
+- Structure the content to mirror the system's architecture, not the user's learning path
+- Write each entry assuming the reader already knows what they're looking for
+- Place warnings and constraints before descriptions, not after
+- Include examples that illustrate usage without teaching or explaining
+- Remove any content that reads like a tutorial or guide
+- Keep descriptions neutral by removing opinions and recommendations
+- Write entries that can stand alone without context from other sections
+- Include cross-references only when they clarify technical relationships
+- Group related items by technical similarity, not by use case
+- Write descriptions that work both in isolation and as part of a broader documentation
+- Include version-specific information directly with the feature, not in a separate section
+- Document limitations as inherent properties, not as warnings
+- Structure content to support both browsing and direct access
+- Write for lookup and verification, not for learning
+- Remove any content that explains why something works the way it does

--- a/.github/instructions/reference.instructions.md.license
+++ b/.github/instructions/reference.instructions.md.license
@@ -1,0 +1,6 @@
+
+This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+
+SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ For more detailed instructions, check out the [installation guide](docs/guides/i
 
 - [About the tech stack](docs/explanations/tech-stack.md)
 - [About deployments](docs/explanations/deployment.md)
+- [About styling and visual grammar](docs/explanations/styling.md)
+- [About the integration with the spezi web design system components](docs/explanations/design-system-components.md)
+
+## Reference
+
+- [Color tokens reference](docs/reference/color-tokens.md)
 
 ## Contributing
 

--- a/docs/explanations/design-system-components.md
+++ b/docs/explanations/design-system-components.md
@@ -1,0 +1,68 @@
+<!--
+
+This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+
+SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT
+
+-->
+
+# About the integration with the spezi web design system components
+
+## Purpose and scope
+
+This document explains how the study platform integrates components from the [spezi-web-design-system](https://github.com/StanfordSpezi/spezi-web-design-system) (SWDS). It focuses on the principles and guidelines that govern when to use SWDS components as-is, when to customize them, and how the platform co-evolves with the SWDS.
+
+## Context
+
+The study platform consumes the SWDS because that it offers accessible, well-tested components and an emerging visual language for the Spezi web brand. At the same time, the platform must present its own product identity and occasionally satisfy interaction patterns that SWDS does not yet cover. The tension between reuse and customization is the central driver of the decisions captured here.
+
+## Guiding principles
+
+The points below translate the high-level reuse-versus-customization dilemma into concrete, practical rules that govern every styling or component decision.
+
+###  1. Start with the design-system default
+
+Every new screen or feature begins by dropping in the unmodified SWDS component. If the result already fits the design mock-up, nothing further happens. This keeps upgrade paths short and the code surface small.
+
+### 2. Customize only as shallowly as necessary
+
+When the default falls short, the first attempt is always a lightweight fix: an extra utility class, a Tailwind variant or a single CSS override. Deep rewrites or forks are a last resort because they create a new maintenance burden.
+
+### 3. Surface good customizations upstream
+
+If a local override clearly improves the generic experience, an issue or pull request is opened in SWDS. Sharing improvements prevents multiple projects from solving the same problem in isolation.
+
+### 4. Accept minor mismatches when cost outweighs benefit
+
+If a default component is slightly off but still functional, live with the discrepancy and document it rather than create long-term maintenance work.
+
+## Component integration guidelines
+
+Choosing between “use the default” and “customize” can be confusing, especially for new contributors. The framework below maps common scenarios to clear actions.
+
+| Scenario                   | Signs you are in this scenario                                                                             | Recommended action                                             | Rationale                                               |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------- |
+| 1. Accept the default      | The SWDS component meets functional needs. Minor spacing or color tweaks are cosmetic.                     | Use as-is, adding only utility classes or small CSS overrides. | Lowest maintenance cost.                                |
+| 2. Accept a minor mismatch | The default feels slightly off but still achieves the user outcome (e.g., dropdown alignment preferences). | Live with the discrepancy, document the friction.              | Upgrades remain trivial, avoid premature customization. |
+| 3. Improve for everyone    | A local variant is clearly better and useful beyond this project (e.g., an improved button shadow model).  | Implement locally and open an upstream proposal to SWDS.       | Keeps the ecosystem coherent and reduces future drift.  |
+| 4. Fork deliberately       | Requirement is unique or fundamentally different (e.g., a highly specialised sidebar component).           | Copy the component into the repo, own the code.                | Makes the fork explicit and contained.                  |
+
+Placing “accept the mismatch” before “improve for everyone” ensures that we don't chase micro-optimisations that add long-term cost.
+
+## Known limitations and how they are handled
+
+Even with these rules in place, certain drawbacks remain. The list that follows describes those constraints, why they are acceptable, and strategies to mitigate their impact.
+
+### Component drift
+
+Components may diverge from SWDS over time, especially if local customizations accumulate. To manage this, it is important to only fork or heavily customize components when absolutely necessary. Regularly review local overrides to see if they can be upstreamed or simplified.
+
+### Upstream lag
+
+SWDS may accept proposed improvements on a slower cadence than the platform evolves. Temporary divergence is considered acceptable. Each open proposal is tracked, and local patches are dropped once an official release contains the same fix.
+
+## Conclusion
+
+By starting with SWDS defaults, limiting the depth of customizations, accepting minor mismatches, and upstreaming broadly useful changes, the study platform achieves a balance between product-specific polish and long-term maintainability.

--- a/docs/explanations/design-system-components.md
+++ b/docs/explanations/design-system-components.md
@@ -40,7 +40,7 @@ If a default component is slightly off but still functional, live with the discr
 
 ## Component integration guidelines
 
-Choosing between “use the default” and “customize” can be confusing, especially for new contributors. The framework below maps common scenarios to clear actions.
+Choosing between "use the default" and "customize" can be confusing, especially for new contributors. The framework below maps common scenarios to clear actions. The order reflects precedence: always consider the less disruptive option first.
 
 | Scenario                   | Signs you are in this scenario                                                                             | Recommended action                                             | Rationale                                               |
 | -------------------------- | ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------- |
@@ -49,9 +49,9 @@ Choosing between “use the default” and “customize” can be confusing, esp
 | 3. Improve for everyone    | A local variant is clearly better and useful beyond this project (e.g., an improved button shadow model).  | Implement locally and open an upstream proposal to SWDS.       | Keeps the ecosystem coherent and reduces future drift.  |
 | 4. Fork deliberately       | Requirement is unique or fundamentally different (e.g., a highly specialised sidebar component).           | Copy the component into the repo, own the code.                | Makes the fork explicit and contained.                  |
 
-Placing “accept the mismatch” before “improve for everyone” ensures that we don't chase micro-optimisations that add long-term cost.
+Placing "accept the mismatch" before "improve for everyone" ensures that we don't chase micro-optimisations that add long-term cost.
 
-## Known limitations and how they are handled
+## Limitations and how they are handled
 
 Even with these rules in place, certain drawbacks remain. The list that follows describes those constraints, why they are acceptable, and strategies to mitigate their impact.
 

--- a/docs/explanations/design-system-components.md
+++ b/docs/explanations/design-system-components.md
@@ -47,7 +47,7 @@ Choosing between "use the default" and "customize" can be confusing, especially 
 | 1. Accept the default      | The SWDS component meets functional needs. Minor spacing or color tweaks are cosmetic.                     | Use as-is, adding only utility classes or small CSS overrides. | Lowest maintenance cost.                                |
 | 2. Accept a minor mismatch | The default feels slightly off but still achieves the user outcome (e.g., dropdown alignment preferences). | Live with the discrepancy, document the friction.              | Upgrades remain trivial, avoid premature customization. |
 | 3. Improve for everyone    | A local variant is clearly better and useful beyond this project (e.g., an improved button shadow model).  | Implement locally and open an upstream proposal to SWDS.       | Keeps the ecosystem coherent and reduces future drift.  |
-| 4. Fork deliberately       | Requirement is unique or fundamentally different (e.g., a highly specialised sidebar component).           | Copy the component into the repo, own the code.                | Makes the fork explicit and contained.                  |
+| 4. Fork deliberately       | Requirement is unique or fundamentally different (e.g., a highly specialized sidebar component).           | Copy the component into the repo, own the code.                | Makes the fork explicit and contained.                  |
 
 Placing "accept the mismatch" before "improve for everyone" ensures that we don't chase micro-optimisations that add long-term cost.
 

--- a/docs/explanations/styling.md
+++ b/docs/explanations/styling.md
@@ -49,7 +49,7 @@ To keep intent explicit the platform adopts a semantic token hierarchy, inspired
 - The color’s purpose (brand, success, warning, neutral, etc.).
 - Optional interaction states (hover, active, disabled) and prominence levels (primary, secondary, tertiary).
 
-Learn more about each individual token in the [color token reference](../reference//color-tokens.md).
+Learn more about each individual token in the [color token reference](../reference/color-tokens.md).
 
 ### Naming convention
 

--- a/docs/explanations/styling.md
+++ b/docs/explanations/styling.md
@@ -1,0 +1,95 @@
+<!--
+
+This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+
+SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT
+
+-->
+
+# About styling and visual grammar
+
+## Purpose and scope
+
+This document captures the reasoning behind the study platform's visual-styling approach, with special focus on the semantic color-token system. It explains why this scheme exists, the benefits it brings, and the trade-offs it introduces.
+
+## Context
+
+The platform targets a broad, mostly non-technical audience that wants to create and manage studies with minimal friction. The standard [spezi-web-design-system](https://github.com/StanfordSpezi/spezi-web-design-system) (SWDS) styles provide a solid baseline, but some adjustments are required to meet the specific UX goals of this project. The styling approach therefore balances two objectives:
+
+1. Reuse of existing SWDS primitives to simplify maintenance and preserve brand alignment.
+2. Adaptation where usability for this project would measurably benefit.
+
+## Guiding principles
+
+The following principles guide the design and implementation of the platform’s styling system:
+
+### 1. State intent first
+
+Name design primitives by purpose (“emphasis text”, “brand fill”) before assigning concrete values. This keeps future theme changes predictable.
+
+### 2. Single source of design data
+
+Tokens for color, spacing, and typography live in one place. Redundant declarations are avoided.
+
+### 3. Start with design-system defaults, extend only when necessary
+
+New tokens appear only when the existing set cannot express a real UI need.
+
+## Semantic color tokens
+
+The default SWDS palette is intentionally compact to stay beginner-friendly. The study platform, however, requires a more complex set of color tokens to handle different background layers, component states and contexts.
+
+Without a structured token hierarchy these needs would be met by improvised hex values or intentless primitive color tokens sprinkled throughout the codebase. That hidden complexity makes maintenance difficult, especially when updating themes or ensuring accessibility.
+
+To keep intent explicit the platform adopts a semantic token hierarchy, inspired by [Shopify Polaris](https://polaris-react.shopify.com/design/colors), that encodes:
+
+- The physical layer being colored (background, surface, border, text, icon).
+- The color’s purpose (brand, success, warning, neutral, etc.).
+- Optional interaction states (hover, active, disabled) and prominence levels (primary, secondary, tertiary).
+
+Learn more about each individual token in the [color token reference](../reference//color-tokens.md).
+
+### Naming convention
+
+color-[concept]-[element]-[role]-[prominence]-[state]
+
+| Segment    | Meaning (examples)                                                              |
+| ---------- | ------------------------------------------------------------------------------- |
+| concept    | Optional domain context such as nav or sidebar . Omitted for global tokens      |
+| element    | The physical layer: bg, surface, fill, border, text, icon.                      |
+| role       | Why the color exists: default, brand, info, success, caution, warning, critical |
+| prominence | Visual strength: primary, secondary, tertiary                                   |
+| state      | Interaction state: hover, active, selected, disabled, focus                     |
+
+A token therefore reads like a sentence. Example:
+`--color-fill-brand-hover` = _“the hover state of a brand-colored fill”_
+
+### Relationship to SWDS tokens
+
+This repository re-maps essential SWDS tokens ( `--color-surface`, `--color-primary`, …) to the new variables. This keeps SWDS components functional out-of-the-box while granting the study platform finer control where needed.
+
+### Benefits and trade-offs
+
+- Predictability: Designers and engineers can infer the intent of a color from its name alone.
+- Accessibility: By pairing text tokens (on-fill variants) with their corresponding backgrounds, color-contrast rules can be audited systematically.
+- Easier theming: Theming changes require changing token definitions, not refactoring every component.
+
+The cost is a steeper learning curve: contributors must grasp more design tokens to work effectively. The project considers this an upfront investment that prevents brittle hacks later.
+
+## Known limitations and how they are handled
+
+Even with these rules in place, certain drawbacks remain. The list that follows describes those constraints, why they are acceptable, and strategies to mitigate their impact.
+
+### Token proliferation
+
+A semantic system invites new tokens each time someone spots a nuance. Runaway growth would blur the meaning of existing names. Every new token therefore requires a short explanation of its purpose and how it differs from similar tokens. This keeps the palette manageable and ensures that each token has a clear, distinct role.
+
+### Higher cognitive load
+
+Contributors must learn a larger vocabulary of colors than the standard SWDS palette demands. The trade-off is accepted because once learned, the system removes the need to search for arbitrary hex codes.
+
+## Conclusion
+
+The styling approach adopted by the study platform balances consistency, maintainability, and flexibility. By building upon the existing Spezi Web Design System (SWDS) and extending it only when necessary, the platform ensures alignment with established design patterns while accommodating specific usability requirements. The semantic token system, central to this approach, explicitly encodes design intent, facilitating clearer communication among designers and developers, easier theming, and systematic accessibility checks. Although this introduces an initial learning curve and increased cognitive load, the long-term benefits of predictability, reduced maintenance complexity, and adaptability to future design changes justify the investment.

--- a/docs/explanations/styling.md
+++ b/docs/explanations/styling.md
@@ -27,7 +27,7 @@ The following principles guide the design and implementation of the platform’s
 
 ### 1. State intent first
 
-Name design primitives by purpose (“emphasis text”, “brand fill”) before assigning concrete values. This keeps future theme changes predictable.
+Name design primitives by purpose ("secondary icon", "brand fill") rather than appearance ("blue", "large"). This makes the intent of each token explicit and reduces cognitive load when reading code.
 
 ### 2. Single source of design data
 
@@ -78,7 +78,7 @@ This repository re-maps essential SWDS tokens ( `--color-surface`, `--color-prim
 
 The cost is a steeper learning curve: contributors must grasp more design tokens to work effectively. The project considers this an upfront investment that prevents brittle hacks later.
 
-## Known limitations and how they are handled
+## Limitations and how they are handled
 
 Even with these rules in place, certain drawbacks remain. The list that follows describes those constraints, why they are acceptable, and strategies to mitigate their impact.
 

--- a/docs/explanations/styling.md
+++ b/docs/explanations/styling.md
@@ -70,13 +70,16 @@ A token therefore reads like a sentence. Example:
 
 This repository re-maps essential SWDS tokens ( `--color-surface`, `--color-primary`, …) to the new variables. This keeps SWDS components functional out-of-the-box while granting the study platform finer control where needed.
 
-### Benefits and trade-offs
+### Benefits
 
 - Predictability: Designers and engineers can infer the intent of a color from its name alone.
 - Accessibility: By pairing text tokens (on-fill variants) with their corresponding backgrounds, color-contrast rules can be audited systematically.
 - Easier theming: Theming changes require changing token definitions, not refactoring every component.
 
-The cost is a steeper learning curve: contributors must grasp more design tokens to work effectively. The project considers this an upfront investment that prevents brittle hacks later.
+### Trade-offs
+
+- Centralization reduces modularity: Centralizing tokens ensures consistency, accessibility, and easier theming across the platform, but it makes components more interdependent.
+- Steeper learning curve: Contributors must grasp more design tokens to work effectively. This upfront investment reduces ambiguity and prevents inconsistencies in design and styling patterns.
 
 ## Limitations and how they are handled
 

--- a/docs/explanations/styling.md
+++ b/docs/explanations/styling.md
@@ -92,4 +92,4 @@ Contributors must learn a larger vocabulary of colors than the standard SWDS pal
 
 ## Conclusion
 
-The styling approach adopted by the study platform balances consistency, maintainability, and flexibility. By building upon the existing Spezi Web Design System (SWDS) and extending it only when necessary, the platform ensures alignment with established design patterns while accommodating specific usability requirements. The semantic token system, central to this approach, explicitly encodes design intent, facilitating clearer communication among designers and developers, easier theming, and systematic accessibility checks. Although this introduces an initial learning curve and increased cognitive load, the long-term benefits of predictability, reduced maintenance complexity, and adaptability to future design changes justify the investment.
+The styling approach adopted by the study platform balances consistency, maintainability, and flexibility. By building upon the existing SWDS and extending it only when necessary, the platform ensures alignment with established design patterns while accommodating specific usability requirements.

--- a/docs/reference/color-tokens.md
+++ b/docs/reference/color-tokens.md
@@ -1,0 +1,244 @@
+<!--
+
+This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+
+SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT
+
+-->
+
+# Color tokens reference
+
+This document provides a reference for the semantic color tokens used in the study platform. Each token is designed to express a specific visual intent, ensuring consistency and clarity across the user interface. Learn more about the design of the [semantic color token system](../explanations/styling.md#semantic-color-tokens).
+
+## Tokens
+
+### Background
+
+These styles apply to the background color of an element, typically used for larger areas like the main content area or sidebars.
+
+#### Primary
+
+- `bg`: Used for the main background of the application, providing a neutral base for content.
+- `bg-hover`: Used to style the hover state of elements that sit on the primary background.
+- `bg-active`: Used to style the active state of elements that sit on the primary background.
+
+#### Secondary
+
+- `bg-secondary`: Used for secondary backgrounds, such as sidebars or secondary content areas, providing a subtle yet distinct visual separation from the primary background.
+- `bg-secondary-hover`: Used to style the hover state of elements that sit on a secondary background.
+- `bg-secondary-active`: Used to style the active state of elements that sit on a secondary background.
+
+#### Examples
+
+```tsx
+<Layout>
+  <Sidebar className="bg-bg-secondary">
+    <SidebarItem className="hover:bg-bg-secondary-hover active:bg-bg-secondary-active" />
+  </Sidebar>
+  <MainContent className="bg-bg">
+    <GhostButton className="hover:bg-bg-hover active:bg-bg-active" />
+  </MainContent>
+</Layout>
+```
+
+### Surface
+
+These styles apply to larger elements that sit on top of the background, such as cards, panels, or other "container-like" UI components that require a distinct visual separation from the background.
+
+#### Primary
+
+- `surface`: Used for elements that sit on the primary background, such as cards or panels, providing a subtle elevation effect.
+- `surface-hover`: Used to style the hover state of elements that sit on the primary surface.
+
+#### Examples
+
+```tsx
+<Background className="bg-bg">
+  <Card className="bg-surface">
+    <GhostButton className="hover:bg-surface-hover" />
+  </Card>
+</Background>
+```
+
+### Fill
+
+These styles apply to smaller elements that require a solid fill color, such as buttons or badges. Fills come with their explicit text and icon colors, called `on-fill` tokens, to ensure good contrast and readability.
+
+#### Default
+
+- `fill`: Used for elements that require a solid neutral fill color that does not express a specific intent and does not fit a particular role.
+
+#### Brand
+
+- `fill-brand`: Used for elements that require a solid fill color that draws a lot of attention to an element without conveying a specific context, such as an error or success state.
+- `fill-brand-hover`: Used to style the hover state of elements that use the brand fill color.
+- `fill-brand-active`: Used to style the active state of elements that use the brand fill color.
+
+#### Success
+
+- `fill-success`: Used for elements that require a solid fill color that indicates a successful or positive action or state, such as a completed task or successful submission.
+
+#### Warning
+
+- `fill-warning`: Used for elements that require a solid fill color that indicates a warning action or pending state, such as a potential issue or caution.
+
+#### Critical
+
+- `fill-critical`: Used for elements that require a solid fill color that indicates an error or high importance state, such as a failed action or critical alert.
+
+#### Examples
+
+```tsx
+<Table>
+  <TableHeader className="bg-fill" />
+</Table>
+```
+
+```tsx
+<ModalFooter>
+  <Button className="bg-fill-brand hover:bg-fill-brand-hover active:bg-fill-brand-active">
+    New Study
+  </Button>
+</ModalFooter>
+```
+
+```tsx
+<CardHeader>
+  <Badge className="bg-fill-success">Completed</Badge>
+</CardHeader>
+```
+
+```tsx
+<Banner>
+  <BannerHeader className="bg-fill-warning">Maintenance Notice</BannerHeader>
+</Banner>
+```
+
+```tsx
+<Popover>
+  <PopoverContent className="bg-fill-critical">Error occurred</PopoverContent>
+</Popover>
+```
+
+### Border
+
+These styles apply to the border or ring color of elements, typically used for outlines or borders around cards, buttons, and other UI components.
+
+#### Default
+
+- `border`: Used for elements that require an unopinionated strong border color to provide visual separation or emphasis without conveying a specific intent.
+
+##### Focus
+
+- `border-focus`: Used to style the border color of elements when they are focused, ensuring good visibility and accessibility.
+
+##### Examples
+
+```tsx
+<Card className="border-border border">
+  <CardHeader className="border-border border-b">
+    <Button className="focus-visible:ring-border-focus focus-visible:ring-2" />
+  </CardHeader>
+</Card>
+```
+
+### Text
+
+These styles apply to the text color of elements, ensuring good contrast and readability.
+
+#### Default
+
+###### Primary
+
+- `text`: Used for the emphasized texts, such as headings or important labels, providing a strong visual presence.
+
+###### Secondary
+
+- `text-secondary`: Used for basic text around the application, such as body text. This is the default text color for most text elements, providing a neutral and readable appearance.
+
+###### Tertiary
+
+- `text-tertiary`: Used for less emphasized text, such as captions or secondary information, providing a subtler contrast.
+
+#### On Fill
+
+- `text-on-fill`: Used for text that appears on elements with a neutral fill color.
+- `text-brand-on-fill`: Used for text that appears on elements with a brand fill color.
+- `text-success-on-fill`: Used for text that appears on elements with a success fill color.
+- `text-warning-on-fill`: Used for text that appears on elements with a warning fill color.
+- `text-critical-on-fill`: Used for text that appears on elements with a critical fill color.
+
+##### Examples
+
+```tsx
+<Card>
+  <Heading className="text-text">Welcome to the Study Platform</Heading>
+  <Paragraph className="text-text-secondary">
+    Login to access your studies and data.
+  </Paragraph>
+  <Caption className="text-text-tertiary">
+    Don't have an account? <Link className="text-text">Sign up</Link>
+  </Caption>
+</Card>
+```
+
+```tsx
+<Tag className="bg-fill text-on-fill" />
+```
+
+```tsx
+<Pagination>
+  <ActivePage className="bg-fill-brand text-brand-on-fill">1</ActivePage>
+</Pagination>
+```
+
+```tsx
+<CopyButton className="data-[copied=true]:bg-fill-success data-[copied=true]:text-success-on-fill" />
+```
+
+```tsx
+<Badge className="bg-fill-warning text-warning-on-fill">Check your input</Badge>
+```
+
+```tsx
+<Button className="bg-fill-critical text-critical-on-fill">Delete Study</Button>
+```
+
+### Icon
+
+These styles apply to the fill or stroke color of icons, ensuring they are visually distinct and consistent with the overall design.
+
+#### Primary
+
+- `icon`: Used for emphasized icons that require a strong visual presence. Mirrors the `text` token, providing a strong contrast against the background.
+
+#### Secondary
+
+- `icon-secondary`: Used for basic icons. This is the default choice for most icon elements. Mirrors the `text-secondary` token, providing a neutral and readable appearance.
+
+#### Tertiary
+
+- `icon-tertiary`: Used for less emphasized icons, such as decorative or secondary icons. Mirrors the `text-tertiary` token, providing a subtler contrast.
+
+#### Examples
+
+```tsx
+<Card>
+  <Heading className="text-text">
+    <Icon className="text-icon" />
+    Welcome to the Study Platform
+  </Heading>
+  <Paragraph className="text-text-secondary">
+    <Icon className="text-icon-secondary" />
+    Login to access your studies and data.
+  </Paragraph>
+  <Caption className="text-text-tertiary">
+    <Icon className="text-icon-tertiary" />
+    Don't have an account? <Link className="text-text">Sign up</Link>
+  </Caption>
+</Card>
+```
+
+>

--- a/docs/reference/color-tokens.md
+++ b/docs/reference/color-tokens.md
@@ -68,7 +68,7 @@ These styles apply to larger elements that sit on top of the background, such as
 
 ### Fill
 
-These styles apply to smaller elements that require a solid fill color, such as buttons or badges. Fills come with their explicit text and icon colors, called `on-fill` tokens, to ensure good contrast and readability.
+These styles apply to smaller elements that require a solid fill color, such as buttons or badges. Fills come with their explicit text colors, called `on-fill` tokens, to ensure good contrast and readability.
 
 #### Default
 
@@ -83,6 +83,12 @@ These styles apply to smaller elements that require a solid fill color, such as 
 - `fill-brand`: Used for elements that require a solid fill color that draws a lot of attention to an element without conveying a specific context, such as an error or success state.
 - `fill-brand-hover`: Used to style the hover state of elements that use the brand fill color.
 - `fill-brand-active`: Used to style the active state of elements that use the brand fill color.
+
+#### Info
+
+##### Primary
+
+- `fill-info`: Used for elements that require a solid fill color that indicates informational content or commands a little bit of attention. It should be used to put emphasis on elements that don't require action but still need to be noticed.
 
 #### Success
 
@@ -119,6 +125,12 @@ These styles apply to smaller elements that require a solid fill color, such as 
 ```
 
 ```tsx
+<AvatarRole>
+  <AdminIcon className="bg-fill-info" />
+</AvatarRole>
+```
+
+```tsx
 <CardHeader>
   <Badge className="bg-fill-success">Completed</Badge>
 </CardHeader>
@@ -147,11 +159,15 @@ These styles apply to the border or ring color of elements, typically used for o
 - `border`: Used for elements that require an unopinionated strong border color to provide visual separation or emphasis without conveying a specific intent.
 - `border-focus`: Used to style the border color of elements when they are focused, ensuring good visibility and accessibility.
 
+##### Secondary
+
+- `border-secondary`: Used for elements that require an unopinionated border color that is less prominent than the primary border, providing a subtle visual separation.
+
 #### Examples
 
 ```tsx
 <Card className="border-border border">
-  <CardHeader className="border-border border-b">
+  <CardHeader className="border-border-secondary border-b">
     <Button className="focus-visible:ring-border-focus focus-visible:ring-2" />
   </CardHeader>
 </Card>
@@ -159,7 +175,7 @@ These styles apply to the border or ring color of elements, typically used for o
 
 ### Text
 
-These styles apply to the text color of elements, ensuring good contrast and readability.
+These styles apply to the text color of elements, ensuring good contrast and readability. It should also be used to style the fill or stroke colors of icons and other text-like elements.
 
 #### Default
 
@@ -177,31 +193,39 @@ These styles apply to the text color of elements, ensuring good contrast and rea
 
 #### On Fill
 
-##### Primary
+##### Default
+
+###### Primary
 
 - `text-on-fill`: Used for text that appears on elements with a neutral fill color.
 
-#### Brand
+##### Info
 
-##### Primary
+###### Primary
+
+- `text-info-on-fill`: Used for text that appears on elements with a brand fill color.
+
+##### Brand
+
+###### Primary
 
 - `text-brand-on-fill`: Used for text that appears on elements with a brand fill color.
 
-#### Success
+##### Success
 
-##### Primary
+###### Primary
 
 - `text-success-on-fill`: Used for text that appears on elements with a success fill color.
 
-#### Warning
+##### Warning
 
-##### Primary
+###### Primary
 
 - `text-warning-on-fill`: Used for text that appears on elements with a warning fill color.
 
-#### Critical
+##### Critical
 
-##### Primary
+###### Primary
 
 - `text-critical-on-fill`: Used for text that appears on elements with a critical fill color.
 
@@ -224,6 +248,14 @@ These styles apply to the text color of elements, ensuring good contrast and rea
 ```
 
 ```tsx
+<Calendar>
+  <CurrentDay>
+    <NextEvent className="bg-fill-info text-info-on-fill" />
+  </CurrentDay>
+</Calendar>
+```
+
+```tsx
 <Pagination>
   <ActivePage className="bg-fill-brand text-brand-on-fill">1</ActivePage>
 </Pagination>
@@ -240,42 +272,3 @@ These styles apply to the text color of elements, ensuring good contrast and rea
 ```tsx
 <Button className="bg-fill-critical text-critical-on-fill">Delete Study</Button>
 ```
-
-### Icon
-
-These styles apply to the fill or stroke color of icons, ensuring they are visually distinct and consistent with the overall design.
-
-#### Default
-
-##### Primary
-
-- `icon`: Used for emphasized icons that require a strong visual presence. Mirrors the `text` token, providing a strong contrast against the background.
-
-##### Secondary
-
-- `icon-secondary`: Used for basic icons. This is the default choice for most icon elements. Mirrors the `text-secondary` token, providing a neutral and readable appearance.
-
-##### Tertiary
-
-- `icon-tertiary`: Used for less emphasized icons, such as decorative or secondary icons. Mirrors the `text-tertiary` token, providing a subtler contrast.
-
-#### Examples
-
-```tsx
-<Card>
-  <Heading className="text-text">
-    <Icon className="text-icon" />
-    Welcome to the Study Platform
-  </Heading>
-  <Paragraph className="text-text-secondary">
-    <Icon className="text-icon-secondary" />
-    Login to access your studies and data.
-  </Paragraph>
-  <Caption className="text-text-tertiary">
-    <Icon className="text-icon-tertiary" />
-    Don't have an account? <Link className="text-text">Sign up</Link>
-  </Caption>
-</Card>
-```
-
->

--- a/docs/reference/color-tokens.md
+++ b/docs/reference/color-tokens.md
@@ -12,19 +12,21 @@ SPDX-License-Identifier: MIT
 
 This document provides a reference for the semantic color tokens used in the study platform. Each token is designed to express a specific visual intent, ensuring consistency and clarity across the user interface. Learn more about the design of the [semantic color token system](../explanations/styling.md#semantic-color-tokens).
 
-## Tokens
+## Global Tokens
 
 ### Background
 
 These styles apply to the background color of an element, typically used for larger areas like the main content area or sidebars.
 
-#### Primary
+#### Default
+
+##### Primary
 
 - `bg`: Used for the main background of the application, providing a neutral base for content.
 - `bg-hover`: Used to style the hover state of elements that sit on the primary background.
 - `bg-active`: Used to style the active state of elements that sit on the primary background.
 
-#### Secondary
+##### Secondary
 
 - `bg-secondary`: Used for secondary backgrounds, such as sidebars or secondary content areas, providing a subtle yet distinct visual separation from the primary background.
 - `bg-secondary-hover`: Used to style the hover state of elements that sit on a secondary background.
@@ -47,7 +49,9 @@ These styles apply to the background color of an element, typically used for lar
 
 These styles apply to larger elements that sit on top of the background, such as cards, panels, or other "container-like" UI components that require a distinct visual separation from the background.
 
-#### Primary
+#### Default
+
+##### Primary
 
 - `surface`: Used for elements that sit on the primary background, such as cards or panels, providing a subtle elevation effect.
 - `surface-hover`: Used to style the hover state of elements that sit on the primary surface.
@@ -68,9 +72,13 @@ These styles apply to smaller elements that require a solid fill color, such as 
 
 #### Default
 
+##### Primary
+
 - `fill`: Used for elements that require a solid neutral fill color that does not express a specific intent and does not fit a particular role.
 
 #### Brand
+
+##### Primary
 
 - `fill-brand`: Used for elements that require a solid fill color that draws a lot of attention to an element without conveying a specific context, such as an error or success state.
 - `fill-brand-hover`: Used to style the hover state of elements that use the brand fill color.
@@ -78,13 +86,19 @@ These styles apply to smaller elements that require a solid fill color, such as 
 
 #### Success
 
+##### Primary
+
 - `fill-success`: Used for elements that require a solid fill color that indicates a successful or positive action or state, such as a completed task or successful submission.
 
 #### Warning
 
+##### Primary
+
 - `fill-warning`: Used for elements that require a solid fill color that indicates a warning action or pending state, such as a potential issue or caution.
 
 #### Critical
+
+##### Primary
 
 - `fill-critical`: Used for elements that require a solid fill color that indicates an error or high importance state, such as a failed action or critical alert.
 
@@ -128,13 +142,12 @@ These styles apply to the border or ring color of elements, typically used for o
 
 #### Default
 
+##### Primary
+
 - `border`: Used for elements that require an unopinionated strong border color to provide visual separation or emphasis without conveying a specific intent.
-
-##### Focus
-
 - `border-focus`: Used to style the border color of elements when they are focused, ensuring good visibility and accessibility.
 
-##### Examples
+#### Examples
 
 ```tsx
 <Card className="border-border border">
@@ -150,24 +163,46 @@ These styles apply to the text color of elements, ensuring good contrast and rea
 
 #### Default
 
-###### Primary
+##### Primary
 
 - `text`: Used for the emphasized texts, such as headings or important labels, providing a strong visual presence.
 
-###### Secondary
+##### Secondary
 
 - `text-secondary`: Used for basic text around the application, such as body text. This is the default text color for most text elements, providing a neutral and readable appearance.
 
-###### Tertiary
+##### Tertiary
 
 - `text-tertiary`: Used for less emphasized text, such as captions or secondary information, providing a subtler contrast.
 
 #### On Fill
 
+##### Primary
+
 - `text-on-fill`: Used for text that appears on elements with a neutral fill color.
+
+#### Brand
+
+##### Primary
+
 - `text-brand-on-fill`: Used for text that appears on elements with a brand fill color.
+
+#### Success
+
+##### Primary
+
 - `text-success-on-fill`: Used for text that appears on elements with a success fill color.
+
+#### Warning
+
+##### Primary
+
 - `text-warning-on-fill`: Used for text that appears on elements with a warning fill color.
+
+#### Critical
+
+##### Primary
+
 - `text-critical-on-fill`: Used for text that appears on elements with a critical fill color.
 
 ##### Examples
@@ -210,15 +245,17 @@ These styles apply to the text color of elements, ensuring good contrast and rea
 
 These styles apply to the fill or stroke color of icons, ensuring they are visually distinct and consistent with the overall design.
 
-#### Primary
+#### Default
+
+##### Primary
 
 - `icon`: Used for emphasized icons that require a strong visual presence. Mirrors the `text` token, providing a strong contrast against the background.
 
-#### Secondary
+##### Secondary
 
 - `icon-secondary`: Used for basic icons. This is the default choice for most icon elements. Mirrors the `text-secondary` token, providing a neutral and readable appearance.
 
-#### Tertiary
+##### Tertiary
 
 - `icon-tertiary`: Used for less emphasized icons, such as decorative or secondary icons. Mirrors the `text-tertiary` token, providing a subtler contrast.
 


### PR DESCRIPTION
# Add documentation for color and styling

## :recycle: Current situation & Problem
Currently, there is no documentation on the color and styling choices as well as the relationship to the Spezi Web Design System components.

## :gear: Release Notes
### Documentation Updates

* **Instructions for writing references**
Added detailed guidelines for structuring reference documentation, similar to those instructions for writing explanations or guides.

* **Explanation: SWDS integration**
Introduced docs explaining how to integrate and customize components from the Spezi Web Design System. This includes principles for reuse, customization, and upstream contributions, along with strategies to manage limitations like component drift and upstream lag. The doc's content was created from our discussion on #21 

* **Explanation: Styling Approach**
Documented the rationale and principles behind the platform's visual styling with a focus on semantic color tokens.

* **Reference: Color Tokens**
Added a detailed reference for semantic color tokens, covering global tokens for backgrounds, surfaces, fills, borders, text, and icons. Examples illustrate practical usage in UI components.

## :white_check_mark: Testing
Only documentation changes.

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).