### PR TITLE
Closes #23: Add mock auth and sign in flow

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,0 +1,47 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { expect, test } from "@/lib/playwrightFixtures";
+
+test.describe("Authentication Flows", () => {
+  test("redirects to sign-in when not authenticated", async ({ page }) => {
+    await page.goto("/");
+    await expect(page).toHaveURL(/\/sign-in/);
+    await expect(page.getByText("Sign into the study platform")).toBeVisible();
+  });
+
+  test("can sign in and access protected route", async ({ page }) => {
+    await page.goto("/sign-in");
+    await page.getByRole("button", { name: /sign in/i }).click();
+    await expect(page).not.toHaveURL(/\/sign-in/);
+    await page.goto("/");
+    await expect(page).not.toHaveURL(/\/sign-in/);
+  });
+
+  test("logging out redirects to sign-in and blocks dashboard", async ({
+    page,
+  }) => {
+    await page.addSignInScript();
+    await page.goto("/");
+    // Open user dropdown and click sign out
+    await page.getByRole("button", { name: /user menu/i }).click();
+    await page.getByRole("menuitem", { name: /sign out/i }).click();
+    await expect(page).toHaveURL(/\/sign-in/);
+    await page.goto("/");
+    // Try to access dashboard again
+    await expect(page).toHaveURL(/\/sign-in/);
+  });
+
+  test("auth state persists across reloads", async ({ page }) => {
+    await page.addSignInScript();
+    await page.goto("/");
+    await expect(page).not.toHaveURL(/\/sign-in/);
+    await page.reload();
+    await expect(page).not.toHaveURL(/\/sign-in/);
+  });
+});

--- a/e2e/router.spec.ts
+++ b/e2e/router.spec.ts
@@ -7,16 +7,37 @@
 //
 
 import { expect, test } from "@playwright/test";
+import { mockApi } from "@/lib/mockApi";
 
 test("has title", async ({ page }) => {
   await page.goto("/");
   await expect(page).toHaveTitle(/Spezi/);
 });
-test("displays appropriate text on root path", async ({ page }) => {
+
+test("redirects to first available team and study on root path", async ({
+  page,
+}) => {
   await page.goto("/");
   await expect(page.getByText("Study Home Route")).toBeVisible();
-  await expect(page.getByText("team-pine")).toBeVisible();
-  await expect(page.getByText("activity-study")).toBeVisible();
+
+  const [team] = mockApi.team.list();
+  await expect(page.getByText(team.name)).toBeVisible();
+
+  const [study] = mockApi.study.list({ teamId: team.id });
+  await expect(page.getByText(study.title)).toBeVisible();
+});
+
+test("redirects to first available study when accessing team route", async ({
+  page,
+}) => {
+  const [team] = mockApi.team.list();
+
+  await page.goto(`./${team.id}`);
+  await expect(page.getByText("Study Home Route")).toBeVisible();
+  await expect(page.getByText(team.name)).toBeVisible();
+
+  const [study] = mockApi.study.list({ teamId: team.id });
+  await expect(page.getByText(study.title)).toBeVisible();
 });
 
 test("navigates via links and displays correct route text", async ({
@@ -25,7 +46,72 @@ test("navigates via links and displays correct route text", async ({
   await page.goto("/");
   await expect(page.getByText("Study Home Route")).toBeVisible();
 
-  // Click on the "Configuration" link and check for "Configuration Route"
   await page.getByRole("link", { name: "Configuration" }).click();
   await expect(page.getByText("Study Configuration Route")).toBeVisible();
+});
+
+test("displays error page when navigating to non-existent team", async ({
+  page,
+}) => {
+  const invalidTeamId = "invalid-team";
+
+  await page.goto(`./${invalidTeamId}`);
+  await expect(page.getByText("Error")).toBeVisible();
+  await expect(
+    page.getByText(`Team with id ${invalidTeamId} not found`),
+  ).toBeVisible();
+});
+
+test("displays error page when navigating to non-existent study", async ({
+  page,
+}) => {
+  const [team] = mockApi.team.list();
+  const invalidStudyId = "invalid-study";
+
+  await page.goto(`./${team.id}/${invalidStudyId}`);
+  await expect(page.getByText("Error")).toBeVisible();
+  await expect(
+    page.getByText(`Study with id ${invalidStudyId} not found`),
+  ).toBeVisible();
+});
+
+test("team selector displays dynamic teams from mock API", async ({ page }) => {
+  const teams = mockApi.team.list();
+
+  await page.goto("/");
+
+  // Click on the team selector to open the dropdown
+  await page.getByRole("button", { name: teams[0].name }).click();
+
+  // Verify that all teams from the mock API are displayed
+  for (const team of teams) {
+    await expect(page.getByRole("menuitem", { name: team.name })).toBeVisible();
+  }
+});
+
+test("study selector displays dynamic studies from mock API", async ({
+  page,
+}) => {
+  const teams = mockApi.team.list();
+  const studies = mockApi.study.list({ teamId: teams[0].id });
+  const otherStudies = mockApi.study.list({ teamId: teams[1].id });
+
+  await page.goto(`./${teams[0].id}/${studies[0].id}`);
+
+  // Click on the study selector to open the dropdown
+  await page.getByRole("button", { name: studies[0].title }).click();
+
+  // Verify that studies for the current team are displayed
+  for (const study of studies) {
+    await expect(
+      page.getByRole("menuitem", { name: study.title }),
+    ).toBeVisible();
+  }
+
+  // Verify that studies from other teams are not displayed
+  for (const otherStudy of otherStudies) {
+    await expect(
+      page.getByRole("menuitem", { name: otherStudy.title }),
+    ).not.toBeVisible();
+  }
 });

--- a/e2e/router.spec.ts
+++ b/e2e/router.spec.ts
@@ -6,112 +6,126 @@
 // SPDX-License-Identifier: MIT
 //
 
-import { expect, test } from "@playwright/test";
-import { mockApi } from "@/lib/mockApi";
+import { mockDatabase } from "@/lib/mockApi";
+import { expect, test } from "@/lib/playwrightFixtures";
 
-test("has title", async ({ page }) => {
-  await page.goto("/");
-  await expect(page).toHaveTitle(/Spezi/);
-});
+test.describe("Router Tests", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addSignInScript();
+  });
 
-test("redirects to first available team and study on root path", async ({
-  page,
-}) => {
-  await page.goto("/");
-  await expect(page.getByText("Study Home Route")).toBeVisible();
+  test("has title", async ({ page }) => {
+    await page.goto("/");
+    await expect(page).toHaveTitle(/Spezi/);
+  });
 
-  const [team] = mockApi.team.list();
-  await expect(page.getByText(team.name)).toBeVisible();
+  test("redirects to first available team and study on root path", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await expect(page.getByText("Study Home Route")).toBeVisible();
 
-  const [study] = mockApi.study.list({ teamId: team.id });
-  await expect(page.getByText(study.title)).toBeVisible();
-});
+    const [team] = mockDatabase.teams;
+    await expect(page.getByText(team.name)).toBeVisible();
 
-test("redirects to first available study when accessing team route", async ({
-  page,
-}) => {
-  const [team] = mockApi.team.list();
+    const [study] = mockDatabase.studies.filter((s) => s.teamId === team.id);
+    await expect(page.getByText(study.title)).toBeVisible();
+  });
 
-  await page.goto(`./${team.id}`);
-  await expect(page.getByText("Study Home Route")).toBeVisible();
-  await expect(page.getByText(team.name)).toBeVisible();
+  test("redirects to first available study when accessing team route", async ({
+    page,
+  }) => {
+    const [team] = mockDatabase.teams;
 
-  const [study] = mockApi.study.list({ teamId: team.id });
-  await expect(page.getByText(study.title)).toBeVisible();
-});
+    await page.goto(`/${team.id}`);
+    await expect(page.getByText("Study Home Route")).toBeVisible();
+    await expect(page.getByText(team.name)).toBeVisible();
 
-test("navigates via links and displays correct route text", async ({
-  page,
-}) => {
-  await page.goto("/");
-  await expect(page.getByText("Study Home Route")).toBeVisible();
+    const [study] = mockDatabase.studies.filter((s) => s.teamId === team.id);
+    await expect(page.getByText(study.title)).toBeVisible();
+  });
 
-  await page.getByRole("link", { name: "Configuration" }).click();
-  await expect(page.getByText("Study Configuration Route")).toBeVisible();
-});
+  test("navigates via links and displays correct route text", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await expect(page.getByText("Study Home Route")).toBeVisible();
 
-test("displays error page when navigating to non-existent team", async ({
-  page,
-}) => {
-  const invalidTeamId = "invalid-team";
+    await page.getByRole("link", { name: "Configuration" }).click();
+    await expect(page.getByText("Study Configuration Route")).toBeVisible();
+  });
 
-  await page.goto(`./${invalidTeamId}`);
-  await expect(page.getByText("Error")).toBeVisible();
-  await expect(
-    page.getByText(`Team with id ${invalidTeamId} not found`),
-  ).toBeVisible();
-});
+  test("displays error page when navigating to non-existent team", async ({
+    page,
+  }) => {
+    const invalidTeamId = "invalid-team";
 
-test("displays error page when navigating to non-existent study", async ({
-  page,
-}) => {
-  const [team] = mockApi.team.list();
-  const invalidStudyId = "invalid-study";
-
-  await page.goto(`./${team.id}/${invalidStudyId}`);
-  await expect(page.getByText("Error")).toBeVisible();
-  await expect(
-    page.getByText(`Study with id ${invalidStudyId} not found`),
-  ).toBeVisible();
-});
-
-test("team selector displays dynamic teams from mock API", async ({ page }) => {
-  const teams = mockApi.team.list();
-
-  await page.goto("/");
-
-  // Click on the team selector to open the dropdown
-  await page.getByRole("button", { name: teams[0].name }).click();
-
-  // Verify that all teams from the mock API are displayed
-  for (const team of teams) {
-    await expect(page.getByRole("menuitem", { name: team.name })).toBeVisible();
-  }
-});
-
-test("study selector displays dynamic studies from mock API", async ({
-  page,
-}) => {
-  const teams = mockApi.team.list();
-  const studies = mockApi.study.list({ teamId: teams[0].id });
-  const otherStudies = mockApi.study.list({ teamId: teams[1].id });
-
-  await page.goto(`./${teams[0].id}/${studies[0].id}`);
-
-  // Click on the study selector to open the dropdown
-  await page.getByRole("button", { name: studies[0].title }).click();
-
-  // Verify that studies for the current team are displayed
-  for (const study of studies) {
+    await page.goto(`/${invalidTeamId}`);
+    await expect(page.getByText("Error")).toBeVisible();
     await expect(
-      page.getByRole("menuitem", { name: study.title }),
+      page.getByText(`Team with id ${invalidTeamId} not found`),
     ).toBeVisible();
-  }
+  });
 
-  // Verify that studies from other teams are not displayed
-  for (const otherStudy of otherStudies) {
+  test("displays error page when navigating to non-existent study", async ({
+    page,
+  }) => {
+    const [team] = mockDatabase.teams;
+    const invalidStudyId = "invalid-study";
+
+    await page.goto(`/${team.id}/${invalidStudyId}`);
+    await expect(page.getByText("Error")).toBeVisible();
     await expect(
-      page.getByRole("menuitem", { name: otherStudy.title }),
-    ).not.toBeVisible();
-  }
+      page.getByText(`Study with id ${invalidStudyId} not found`),
+    ).toBeVisible();
+  });
+
+  test("team selector displays dynamic teams from mock API", async ({
+    page,
+  }) => {
+    const teams = mockDatabase.teams;
+
+    await page.goto("/");
+
+    // Click on the team selector to open the dropdown
+    await page.getByRole("button", { name: teams[0].name }).click();
+
+    // Verify that all teams from the mock API are displayed
+    for (const team of teams) {
+      await expect(
+        page.getByRole("menuitem", { name: team.name }),
+      ).toBeVisible();
+    }
+  });
+
+  test("study selector displays dynamic studies from mock API", async ({
+    page,
+  }) => {
+    const teams = mockDatabase.teams;
+    const studies = mockDatabase.studies.filter(
+      (s) => s.teamId === teams[0].id,
+    );
+    const otherStudies = mockDatabase.studies.filter(
+      (s) => s.teamId === teams[1].id,
+    );
+
+    await page.goto(`/${teams[0].id}/${studies[0].id}`);
+
+    // Click on the study selector to open the dropdown
+    await page.getByRole("button", { name: studies[0].title }).click();
+
+    // Verify that studies for the current team are displayed
+    for (const study of studies) {
+      await expect(
+        page.getByRole("menuitem", { name: study.title }),
+      ).toBeVisible();
+    }
+
+    // Verify that studies from other teams are not displayed
+    for (const otherStudy of otherStudies) {
+      await expect(
+        page.getByRole("menuitem", { name: otherStudy.title }),
+      ).not.toBeVisible();
+    }
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "react": "^19",
         "react-dom": "^19",
         "tailwind-merge": "^3.3.0",
-        "tailwindcss": "^4.1.7"
+        "tailwindcss": "^4.1.7",
+        "zod": "^3.25.67"
       },
       "devDependencies": {
         "@playwright/test": "^1.52.0",
@@ -4767,10 +4768,9 @@
       }
     },
     "node_modules/@tanstack/history": {
-      "version": "1.115.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.115.0.tgz",
-      "integrity": "sha512-K7JJNrRVvyjAVnbXOH2XLRhFXDkeP54Kt2P4FR1Kl2KDGlIbkua5VqZQD2rot3qaDrpufyUa63nuLai1kOLTsQ==",
-      "license": "MIT",
+      "version": "1.121.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.121.21.tgz",
+      "integrity": "sha512-8BFGA7fpElicM1aEfZRDoEiWgMrNb/fVuJjSKv+nYtbp7jdtqt57fROi/uDGf6PLlgJbMoT3GWxqveZisOUEKA==",
       "engines": {
         "node": ">=12"
       },
@@ -4820,14 +4820,13 @@
       }
     },
     "node_modules/@tanstack/react-router": {
-      "version": "1.120.5",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.120.5.tgz",
-      "integrity": "sha512-A+YRftGwAeFBxa8DF5ujNYqkSEbjCa1KjxDNYr+jWj16jjTxrz/XqgOJCv5ZfbAqqqOa3yLYoQbWa7OGz5jHuA==",
-      "license": "MIT",
+      "version": "1.121.24",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.121.24.tgz",
+      "integrity": "sha512-InxnJfhpa9t+D0SGCGKRAd+FV5lh2H0d+L7tNvXB0bHxpgKiwfcVa/+6Lm2Mx/xWuTW/q3/fZFQcp2ALRwLGVA==",
       "dependencies": {
-        "@tanstack/history": "1.115.0",
+        "@tanstack/history": "1.121.21",
         "@tanstack/react-store": "^0.7.0",
-        "@tanstack/router-core": "1.120.5",
+        "@tanstack/router-core": "1.121.21",
         "jsesc": "^3.1.0",
         "tiny-invariant": "^1.3.3",
         "tiny-warning": "^1.0.3"
@@ -4883,12 +4882,11 @@
       }
     },
     "node_modules/@tanstack/router-core": {
-      "version": "1.120.5",
-      "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.120.5.tgz",
-      "integrity": "sha512-IXLNv3j7rpTL/YNCWHijZgrnxFuvD4Nz/nUiGSak4x5BKzlnuZEso81xFcIuczVrEW72NxZv8IfzpR5M5Tuc0A==",
-      "license": "MIT",
+      "version": "1.121.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.121.21.tgz",
+      "integrity": "sha512-QX27A00EFkCfYcH2e9ikXk/rlWxhVnqS+2QGgnYN1R6MzlvhBYwt7XdenhylJdviVED654dkr1Zma84QjGImIA==",
       "dependencies": {
-        "@tanstack/history": "1.115.0",
+        "@tanstack/history": "1.121.21",
         "@tanstack/store": "^0.7.0",
         "tiny-invariant": "^1.3.3"
       },
@@ -11912,10 +11910,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.51",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.51.tgz",
-      "integrity": "sha512-TQSnBldh+XSGL+opiSIq0575wvDPqu09AqWe1F7JhUMKY+M91/aGlK4MhpVNO7MgYfHcVCB1ffwAUTJzllKJqg==",
-      "license": "MIT",
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@stanfordspezi/spezi-web-design-system": "^0.14.0",
         "@tailwindcss/vite": "^4.1.7",
+        "@tanstack/react-query": "^5.80.7",
         "@tanstack/react-router": "^1.117.1",
         "class-variance-authority": "^0.7.1",
         "radix-ui": "^1.4.2",
@@ -4792,6 +4793,30 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.80.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.80.7.tgz",
+      "integrity": "sha512-s09l5zeUKC8q7DCCCIkVSns8zZrK4ZDT6ryEjxNBFi68G4z2EBobBS7rdOY3r6W1WbUDpc1fe5oY+YO/+2UVUg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.80.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.80.7.tgz",
+      "integrity": "sha512-u2F0VK6+anItoEvB3+rfvTO9GEh2vb00Je05OwlUe/A0lkJBgW1HckiY3f9YZa+jx6IOe4dHPh10dyp9aY3iRQ==",
+      "dependencies": {
+        "@tanstack/query-core": "5.80.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tanstack/react-router": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "react": "^19",
     "react-dom": "^19",
     "tailwind-merge": "^3.3.0",
-    "tailwindcss": "^4.1.7"
+    "tailwindcss": "^4.1.7",
+    "zod": "^3.25.67"
   },
   "devDependencies": {
     "@playwright/test": "^1.52.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@stanfordspezi/spezi-web-design-system": "^0.14.0",
     "@tailwindcss/vite": "^4.1.7",
+    "@tanstack/react-query": "^5.80.7",
     "@tanstack/react-router": "^1.117.1",
     "class-variance-authority": "^0.7.1",
     "radix-ui": "^1.4.2",

--- a/src/components/interfaces/Header/StudySelector.tsx
+++ b/src/components/interfaces/Header/StudySelector.tsx
@@ -7,63 +7,30 @@
 //
 
 import { DropdownMenuSeparator } from "@stanfordspezi/spezi-web-design-system";
+import { useQuery } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
 import { Plus } from "lucide-react";
+import { studyListQueryOptions } from "@/lib/queries/study";
 import {
   HeaderSelector,
   HeaderSelectorMenuItem,
   HeaderSelectorMenuLabel,
 } from "./HeaderSelector";
-
-const studies = [
-  {
-    id: "activity-study",
-    title: "Activity Study",
-    shortTitle: "Activity",
-    explanation: "This is a study about activity.",
-    shortExplanation: "Study about activity.",
-    participationCriteria: "Must be over 18 years old.",
-  },
-  {
-    id: "health-study",
-    title: "Health Study",
-    shortTitle: "Health",
-    explanation: "This is a study about health.",
-    shortExplanation: "Study about health.",
-    participationCriteria: null,
-  },
-  {
-    id: "brain-study",
-    title: "Brain Study",
-    shortTitle: "Brain",
-    explanation: "This is a study about the brain.",
-    shortExplanation: "Study about the brain.",
-    participationCriteria: null,
-  },
-  {
-    id: "dna-study",
-    title: "DNA Study",
-    shortTitle: "DNA",
-    explanation: "This is a study about DNA.",
-    shortExplanation: "Study about DNA.",
-    participationCriteria: null,
-  },
-];
+import { HeaderSelectorSkeleton } from "./HeaderSelectorSkeleton";
 
 export const StudySelector = () => {
-  const { team, study } = useParams({ from: "/(dashboard)/$team/$study" });
-  const selectedStudy = studies.find((s) => s.id === study);
+  const params = useParams({ from: "/(dashboard)/$team/$study" });
+  const { data: studies } = useQuery(
+    studyListQueryOptions({ teamId: params.team }),
+  );
+  const selectedStudy = studies?.find((s) => s.id === params.study);
 
-  // if (!studies) {
-  //   return <HeaderSelectorSkeleton hasIcon={false} />
-  // }
+  if (!studies || !selectedStudy) {
+    return <HeaderSelectorSkeleton hasIcon={false} />;
+  }
 
   return (
-    <HeaderSelector
-      selectedItem={{
-        title: selectedStudy?.title ?? studies[0].title,
-      }}
-    >
+    <HeaderSelector selectedItem={{ title: selectedStudy.title }}>
       <HeaderSelectorMenuLabel>Studies</HeaderSelectorMenuLabel>
       {studies.map((study) => (
         <HeaderSelectorMenuItem
@@ -71,7 +38,7 @@ export const StudySelector = () => {
           linkOptions={{
             to: "/$team/$study",
             params: {
-              team,
+              team: params.team,
               study: study.id,
             },
           }}

--- a/src/components/interfaces/Header/TeamSelector.tsx
+++ b/src/components/interfaces/Header/TeamSelector.tsx
@@ -7,6 +7,7 @@
 //
 
 import { DropdownMenuSeparator } from "@stanfordspezi/spezi-web-design-system";
+import { useQuery } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
 import {
   Flower,
@@ -17,12 +18,13 @@ import {
   TreePine,
   type LucideIcon,
 } from "lucide-react";
+import { teamListQueryOptions } from "@/lib/queries/team";
 import {
   HeaderSelector,
   HeaderSelectorMenuItem,
   HeaderSelectorMenuLabel,
 } from "./HeaderSelector";
-// import { DropdownSelectorSkeleton } from "./DropdownSelectorSkeleton";
+import { HeaderSelectorSkeleton } from "./HeaderSelectorSkeleton";
 
 const iconMap: Record<string, LucideIcon> = {
   TreePine: TreePine,
@@ -32,47 +34,20 @@ const iconMap: Record<string, LucideIcon> = {
   Mountain: Mountain,
 };
 
-const teams = [
-  {
-    id: "team-pine",
-    name: "Team Pine",
-    icon: "TreePine",
-  },
-  {
-    id: "team-tree",
-    name: "Team Tree",
-    icon: "TentTree",
-  },
-  {
-    id: "team-palm",
-    name: "Team Palm",
-    icon: "TreePalm",
-  },
-  {
-    id: "team-flower",
-    name: "Team Flower",
-    icon: "Flower",
-  },
-  {
-    id: "team-mountain",
-    name: "Team Mountain",
-    icon: "Mountain",
-  },
-];
-
 export const TeamSelector = () => {
-  const { team } = useParams({ from: "/(dashboard)/$team/$study" });
-  const selectedTeam = teams.find((t) => t.id === team);
+  const params = useParams({ from: "/(dashboard)/$team/$study" });
+  const { data: teams } = useQuery(teamListQueryOptions());
+  const selectedTeam = teams?.find((t) => t.id === params.team);
 
-  //   if (!teams) {
-  //     return <HeaderSelectorSkeleton hasIcon={true} />;
-  //   }
+  if (!teams || !selectedTeam) {
+    return <HeaderSelectorSkeleton hasIcon={true} />;
+  }
 
   return (
     <HeaderSelector
       selectedItem={{
-        title: selectedTeam?.name ?? teams[0].name,
-        icon: iconMap[selectedTeam?.icon ?? teams[0].icon] ?? TreePine,
+        title: selectedTeam.name,
+        icon: iconMap[selectedTeam.icon] ?? TreePine,
       }}
     >
       <HeaderSelectorMenuLabel>Teams</HeaderSelectorMenuLabel>
@@ -81,10 +56,9 @@ export const TeamSelector = () => {
           key={team.id}
           icon={iconMap[team.icon] ?? TreePine}
           linkOptions={{
-            to: "/$team/$study",
+            to: "/$team",
             params: {
               team: team.id,
-              study: "activity-study", // Todo: This should be dynamic based on the selected team
             },
           }}
         >

--- a/src/components/interfaces/Header/UserDropdown.tsx
+++ b/src/components/interfaces/Header/UserDropdown.tsx
@@ -16,27 +16,36 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@stanfordspezi/spezi-web-design-system";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
 import { Layers2, LogOut, User } from "lucide-react";
+import { mockApi } from "@/lib/mockApi";
+import { currentUserQueryOptions } from "@/lib/queries/currentUser";
 import { cn } from "@/utils/cn";
+import { UserDropdownSkeleton } from "./UserDropdownSkeleton";
+
 // import { UserDropdownSkeleton } from "./UserDropdownSkeleton";
 
-const session = {
-  user: {
-    name: "John Doe",
-    email: "john@example.com",
-    image: undefined,
-  },
-};
-
 export const UserDropdown = () => {
-  // if (!session) {
-  //   return <UserDropdownSkeleton />;
-  // }
+  const { data: user } = useQuery(currentUserQueryOptions());
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  const handleSignOut = async () => {
+    mockApi.auth.signOut();
+    queryClient.clear();
+    await navigate({ to: "/sign-in" });
+  };
+
+  if (!user) {
+    return <UserDropdownSkeleton />;
+  }
 
   return (
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
         <button
+          aria-label="User menu"
           className={cn(
             "flex h-8 items-center gap-3 rounded-md p-1 text-left text-sm outline-hidden",
             "hover:bg-bg-secondary-hover",
@@ -46,10 +55,10 @@ export const UserDropdown = () => {
         >
           <Avatar
             className="bg-surface border-border-secondary size-6.5! rounded-full border bg-clip-padding shadow-xs"
-            src={session.user.image}
+            src={user.imageUrl}
             fallback={
               <div className="bg-surface flex-center size-full rounded-full text-xs">
-                {session.user.name[0].toUpperCase()}
+                {user.name[0].toUpperCase()}
               </div>
             }
           />
@@ -62,10 +71,8 @@ export const UserDropdown = () => {
         sideOffset={4}
       >
         <DropdownMenuLabel>
-          <div>{session.user.name}</div>
-          <div className="text-text-tertiary truncate">
-            {session.user.email}
-          </div>
+          <div>{user.name}</div>
+          <div className="text-text-tertiary truncate">{user.email}</div>
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
         <DropdownMenuGroup>
@@ -79,9 +86,9 @@ export const UserDropdown = () => {
           </DropdownMenuItem>
         </DropdownMenuGroup>
         <DropdownMenuSeparator />
-        <DropdownMenuItem>
+        <DropdownMenuItem onClick={handleSignOut}>
           <LogOut />
-          Log out
+          Sign out
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/components/interfaces/Sidebar/MainNav.tsx
+++ b/src/components/interfaces/Sidebar/MainNav.tsx
@@ -74,7 +74,7 @@ const MainNavButton = ({ item }: { item: NavBarItem }) => {
         tooltip={item.title}
         isActive={!!matchRoute({ to: item.linkOptions.to })}
       >
-        <Link {...item.linkOptions}>
+        <Link from="/" {...item.linkOptions}>
           {item.icon && <item.icon />}
           <span>{item.title}</span>
         </Link>

--- a/src/lib/mockApi/index.ts
+++ b/src/lib/mockApi/index.ts
@@ -6,29 +6,31 @@
 // SPDX-License-Identifier: MIT
 //
 
+import { createMockApi, MockApiError } from "@/utils/createMockApi";
 import { mockStudies } from "./study";
-import { mockTeams } from "./team";
+import { mockTeams, mockUserTeams } from "./team";
+import { mockAdminUser, mockCurrentUser, mockUsers } from "./user";
 
-const mockDatabase = {
+// If you make changes to the mock API database, please make sure to
+// to update / clear the mock database in the localStorage as well.
+// By default, the mock database is persisted in localStorage and not recreated
+// on every page load to simulate a more realistic environment.
+export const mockDatabase = {
+  // Auth
+  currentUser: mockCurrentUser,
+  // Entities
   teams: mockTeams,
   studies: mockStudies,
+  users: mockUsers,
+  // Relationships
+  userTeams: mockUserTeams,
 };
 
 /**
  * The mock database is stored in localStorage to persist across page reloads.
  * This allows the mock API to simulate a more realistic environment.
- * If localStorage is not available (e.g., in Node.js environments),
- * it falls back to an in-memory mock database.
  */
 const getMockDatabase = () => {
-  // In Playwright’s test runner there is no window.localStorage
-  if (
-    typeof window === "undefined" ||
-    typeof window.localStorage === "undefined"
-  ) {
-    return mockDatabase;
-  }
-
   const mockApi = localStorage.getItem("mock-api");
   if (mockApi) {
     return JSON.parse(mockApi) as typeof mockDatabase;
@@ -38,31 +40,123 @@ const getMockDatabase = () => {
 };
 
 /**
+ * Updates the mock database in localStorage.
+ * This function merges the provided data with the existing mock database.
+ */
+const setMockDatabase = (data: Partial<typeof mockDatabase>) => {
+  const currentData = getMockDatabase();
+  const updatedData = { ...currentData, ...data };
+  localStorage.setItem("mock-api", JSON.stringify(updatedData));
+  return updatedData;
+};
+
+/**
  * Mock API for simulating backend interactions.
  * This API is used for testing and development purposes.
  */
-export const mockApi = {
+export const mockApi = createMockApi({
   team: {
     list: () => {
-      const { teams } = getMockDatabase();
-      return teams;
+      const { currentUser, teams, userTeams } = getMockDatabase();
+      if (!currentUser) {
+        throw new MockApiError("No current user found", 401);
+      }
+      if (currentUser.role === "admin") {
+        return teams;
+      }
+      return teams.filter((team) =>
+        userTeams.some(
+          ({ userId, teamId }) =>
+            userId === currentUser.id && teamId === team.id,
+        ),
+      );
     },
     detail: (teamId: string) => {
-      const { teams } = getMockDatabase();
-      return teams.find((team) => team.id === teamId);
+      const { currentUser, teams, userTeams } = getMockDatabase();
+      if (!currentUser) {
+        throw new MockApiError("No current user found", 401);
+      }
+      const team = teams.find((t) => t.id === teamId);
+      if (!team) {
+        throw new MockApiError(`Team with id ${teamId} not found`, 404);
+      }
+      if (currentUser.role === "admin") {
+        return team;
+      }
+      const isMember = userTeams.some(
+        (ut) => ut.userId === currentUser.id && ut.teamId === team.id,
+      );
+      if (!isMember) {
+        throw new MockApiError("User is not part of this team", 403);
+      }
+      return team;
     },
   },
   study: {
     list: (query?: { teamId?: string }) => {
-      const { studies } = getMockDatabase();
-      if (query?.teamId) {
-        return studies.filter((study) => study.teamId === query.teamId);
+      const { currentUser, userTeams, studies } = getMockDatabase();
+      if (!currentUser) {
+        throw new MockApiError("No current user found", 401);
       }
-      return studies;
+      let selectedStudies = studies;
+      if (query?.teamId) {
+        selectedStudies = selectedStudies.filter(
+          (s) => s.teamId === query.teamId,
+        );
+      }
+      if (!selectedStudies.length) {
+        throw new MockApiError("No studies found", 404);
+      }
+      if (currentUser.role === "admin") {
+        return selectedStudies;
+      }
+      const teamIds = userTeams
+        .filter((ut) => ut.userId === currentUser.id)
+        .map((ut) => ut.teamId);
+      const filtered = selectedStudies.filter((s) =>
+        teamIds.includes(s.teamId),
+      );
+      if (!filtered.length) {
+        throw new MockApiError("No studies found for user's teams", 404);
+      }
+      return filtered;
     },
     detail: (studyId: string) => {
-      const { studies } = getMockDatabase();
-      return studies.find((study) => study.id === studyId);
+      const { currentUser, userTeams, studies } = getMockDatabase();
+      if (!currentUser) {
+        throw new MockApiError("No current user found", 401);
+      }
+      const study = studies.find((s) => s.id === studyId);
+      if (!study) {
+        throw new MockApiError(`Study with id ${studyId} not found`, 404);
+      }
+      if (currentUser.role === "admin") {
+        return study;
+      }
+      const allowed = userTeams.some(
+        (ut) => ut.userId === currentUser.id && ut.teamId === study.teamId,
+      );
+      if (!allowed) {
+        throw new MockApiError("User is not part of this study's team", 403);
+      }
+      return study;
     },
   },
-};
+  auth: {
+    signIn: () => {
+      setMockDatabase({ currentUser: mockAdminUser });
+      return mockAdminUser;
+    },
+    signOut: () => {
+      setMockDatabase({ currentUser: null });
+      return null;
+    },
+    getCurrentUser: () => {
+      const { currentUser } = getMockDatabase();
+      if (!currentUser) {
+        throw new MockApiError("No current user found", 401);
+      }
+      return currentUser;
+    },
+  },
+});

--- a/src/lib/mockApi/index.ts
+++ b/src/lib/mockApi/index.ts
@@ -1,0 +1,68 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { mockStudies } from "./study";
+import { mockTeams } from "./team";
+
+const mockDatabase = {
+  teams: mockTeams,
+  studies: mockStudies,
+};
+
+/**
+ * The mock database is stored in localStorage to persist across page reloads.
+ * This allows the mock API to simulate a more realistic environment.
+ * If localStorage is not available (e.g., in Node.js environments),
+ * it falls back to an in-memory mock database.
+ */
+const getMockDatabase = () => {
+  // In Playwright’s test runner there is no window.localStorage
+  if (
+    typeof window === "undefined" ||
+    typeof window.localStorage === "undefined"
+  ) {
+    return mockDatabase;
+  }
+
+  const mockApi = localStorage.getItem("mock-api");
+  if (mockApi) {
+    return JSON.parse(mockApi) as typeof mockDatabase;
+  }
+  localStorage.setItem("mock-api", JSON.stringify(mockDatabase));
+  return mockDatabase;
+};
+
+/**
+ * Mock API for simulating backend interactions.
+ * This API is used for testing and development purposes.
+ */
+export const mockApi = {
+  team: {
+    list: () => {
+      const { teams } = getMockDatabase();
+      return teams;
+    },
+    detail: (teamId: string) => {
+      const { teams } = getMockDatabase();
+      return teams.find((team) => team.id === teamId);
+    },
+  },
+  study: {
+    list: (query?: { teamId?: string }) => {
+      const { studies } = getMockDatabase();
+      if (query?.teamId) {
+        return studies.filter((study) => study.teamId === query.teamId);
+      }
+      return studies;
+    },
+    detail: (studyId: string) => {
+      const { studies } = getMockDatabase();
+      return studies.find((study) => study.id === studyId);
+    },
+  },
+};

--- a/src/lib/mockApi/study.ts
+++ b/src/lib/mockApi/study.ts
@@ -1,0 +1,51 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+interface Study {
+  id: string;
+  title: string;
+  teamId: string;
+}
+
+export const mockStudies: Study[] = [
+  {
+    id: "activity-study",
+    title: "Activity Study",
+    teamId: "team-pine",
+  },
+  {
+    id: "health-study",
+    title: "Health Study",
+    teamId: "team-pine",
+  },
+  {
+    id: "brain-study",
+    title: "Brain Study",
+    teamId: "team-pine",
+  },
+  {
+    id: "dna-study",
+    title: "DNA Study",
+    teamId: "team-tree",
+  },
+  {
+    id: "sleep-study",
+    title: "Sleep Study",
+    teamId: "team-tree",
+  },
+  {
+    id: "nutrition-study",
+    title: "Nutrition Study",
+    teamId: "team-palm",
+  },
+  {
+    id: "stress-study",
+    title: "Stress Study",
+    teamId: "team-flower",
+  },
+];

--- a/src/lib/mockApi/team.ts
+++ b/src/lib/mockApi/team.ts
@@ -1,0 +1,41 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+interface Team {
+  id: string;
+  name: string;
+  icon: string;
+}
+
+export const mockTeams: Team[] = [
+  {
+    id: "team-pine",
+    name: "Team Pine",
+    icon: "TreePine",
+  },
+  {
+    id: "team-tree",
+    name: "Team Tree",
+    icon: "TentTree",
+  },
+  {
+    id: "team-palm",
+    name: "Team Palm",
+    icon: "TreePalm",
+  },
+  {
+    id: "team-flower",
+    name: "Team Flower",
+    icon: "Flower",
+  },
+  {
+    id: "team-mountain",
+    name: "Team Mountain",
+    icon: "Mountain",
+  },
+];

--- a/src/lib/mockApi/team.ts
+++ b/src/lib/mockApi/team.ts
@@ -39,3 +39,13 @@ export const mockTeams: Team[] = [
     icon: "Mountain",
   },
 ];
+
+interface UserTeam {
+  userId: string;
+  teamId: string;
+}
+
+export const mockUserTeams: UserTeam[] = [
+  { userId: "user-1", teamId: "team-pine" },
+  { userId: "user-1", teamId: "team-tree" },
+];

--- a/src/lib/mockApi/user.ts
+++ b/src/lib/mockApi/user.ts
@@ -1,0 +1,35 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+interface User {
+  id: string;
+  name: string;
+  email: string;
+  imageUrl?: string;
+  role: "admin" | "user";
+}
+
+export const mockAdminUser: User = {
+  id: "admin-1",
+  name: "Naomi Price",
+  email: "naomiprice@domain.tld",
+  role: "admin",
+};
+
+export const mockUsers: User[] = [
+  mockAdminUser,
+  {
+    id: "user-1",
+    name: "Vincent Orlowski",
+    email: "vincent_00@domain.tld",
+    imageUrl: "https://avatars.githubusercontent.com/u/133281989?s=200&v=4",
+    role: "user",
+  },
+];
+
+export const mockCurrentUser: User | null = null;

--- a/src/lib/playwrightFixtures.ts
+++ b/src/lib/playwrightFixtures.ts
@@ -1,0 +1,51 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+/* eslint-disable react-hooks/rules-of-hooks */
+import { test as base, type Page } from "@playwright/test";
+import { mockDatabase } from "@/lib/mockApi";
+import { mockAdminUser } from "@/lib/mockApi/user";
+
+type CustomPage = Page & {
+  /**
+   *  Adds a script to the page that simulates a signed-in admin user.
+   * If the mock database is already set in localStorage, it does nothing.
+   */
+  addSignInScript: () => Promise<void>;
+  /**
+   *  Overrides the default goto method to ensure all paths are relative to the root.
+   */
+  _goto: Page["goto"];
+};
+
+export const test = base.extend<{ page: CustomPage }>({
+  page: async ({ page }, use) => {
+    page._goto = page.goto.bind(page);
+    page.goto = (path, options) => {
+      if (path !== "/" && path.startsWith("/")) {
+        path = `.${path}`;
+      }
+      return page._goto(path, options);
+    };
+
+    page.addSignInScript = () => {
+      return page.addInitScript(
+        ({ mockDatabase, mockAdminUser }) => {
+          const existingData = window.localStorage.getItem("mock-api");
+          if (existingData) return;
+          mockDatabase.currentUser = mockAdminUser;
+          window.localStorage.setItem("mock-api", JSON.stringify(mockDatabase));
+        },
+        { mockDatabase, mockAdminUser },
+      );
+    };
+    await use(page);
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/src/lib/queries/currentUser.ts
+++ b/src/lib/queries/currentUser.ts
@@ -1,0 +1,34 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { sleep } from "@stanfordspezi/spezi-web-design-system";
+import { queryOptions } from "@tanstack/react-query";
+import { mockApi } from "../mockApi";
+
+const CURRENT_USER_QUERY_KEY = "currentUser" as const;
+
+/**
+ * Query options for fetching the current user.
+ */
+export const currentUserQueryOptions = () => {
+  return queryOptions({
+    queryKey: [CURRENT_USER_QUERY_KEY],
+    queryFn: async () => {
+      await sleep(100);
+      const response = mockApi.auth.getCurrentUser();
+      if (!response.success) {
+        const { message, status } = response.error;
+        if (status === 401) {
+          throw new Error("Unauthorized");
+        }
+        throw new Error(message);
+      }
+      return response.data;
+    },
+  });
+};

--- a/src/lib/queries/study.ts
+++ b/src/lib/queries/study.ts
@@ -1,0 +1,53 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { sleep } from "@stanfordspezi/spezi-web-design-system";
+import { queryOptions } from "@tanstack/react-query";
+import { queryKeysFactory } from "@/utils/queryKeysFactory";
+import { mockApi } from "../mockApi";
+
+const STUDY_QUERY_KEY = "study" as const;
+export const studyQueryKeys = queryKeysFactory(STUDY_QUERY_KEY);
+
+interface StudyListQueryOptionsParams {
+  teamId?: string;
+}
+
+/**
+ * Query options for fetching a list of studies. Options include filtering by team id.
+ */
+export const studyListQueryOptions = (params: StudyListQueryOptionsParams) => {
+  return queryOptions({
+    queryKey: studyQueryKeys.list(params),
+    queryFn: async () => {
+      await sleep(100);
+      const studies = mockApi.study.list(params);
+      if (studies.length === 0) {
+        throw new Error("No studies found");
+      }
+      return studies;
+    },
+  });
+};
+
+/**
+ * Query options for fetching a specific study by id.
+ */
+export const studyDetailQueryOptions = (studyId: string) => {
+  return queryOptions({
+    queryKey: studyQueryKeys.detail(studyId),
+    queryFn: async () => {
+      await sleep(100);
+      const study = mockApi.study.detail(studyId);
+      if (!study) {
+        throw new Error(`Study with id ${studyId} not found`);
+      }
+      return study;
+    },
+  });
+};

--- a/src/lib/queries/study.ts
+++ b/src/lib/queries/study.ts
@@ -26,11 +26,18 @@ export const studyListQueryOptions = (params: StudyListQueryOptionsParams) => {
     queryKey: studyQueryKeys.list(params),
     queryFn: async () => {
       await sleep(100);
-      const studies = mockApi.study.list(params);
-      if (studies.length === 0) {
-        throw new Error("No studies found");
+      const response = mockApi.study.list(params);
+      if (!response.success) {
+        const { message, status } = response.error;
+        if (status === 404) {
+          return [];
+        }
+        if (status === 401) {
+          throw new Error("Unauthorized");
+        }
+        throw new Error(message);
       }
-      return studies;
+      return response.data;
     },
   });
 };
@@ -43,11 +50,15 @@ export const studyDetailQueryOptions = (studyId: string) => {
     queryKey: studyQueryKeys.detail(studyId),
     queryFn: async () => {
       await sleep(100);
-      const study = mockApi.study.detail(studyId);
-      if (!study) {
-        throw new Error(`Study with id ${studyId} not found`);
+      const response = mockApi.study.detail(studyId);
+      if (!response.success) {
+        const { message, status } = response.error;
+        if (status === 401) {
+          throw new Error("Unauthorized");
+        }
+        throw new Error(message);
       }
-      return study;
+      return response.data;
     },
   });
 };

--- a/src/lib/queries/team.ts
+++ b/src/lib/queries/team.ts
@@ -1,0 +1,50 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { sleep } from "@stanfordspezi/spezi-web-design-system";
+import { queryOptions } from "@tanstack/react-query";
+import { queryKeysFactory } from "@/utils/queryKeysFactory";
+import { mockApi } from "../mockApi";
+
+const TEAM_QUERY_KEY = "team" as const;
+export const teamQueryKeys = queryKeysFactory(TEAM_QUERY_KEY);
+
+/**
+ * Query options for fetching all teams.
+ */
+export const teamListQueryOptions = () => {
+  return queryOptions({
+    queryKey: teamQueryKeys.list(),
+    queryFn: async () => {
+      await sleep(100);
+      const teams = mockApi.team.list();
+      if (teams.length === 0) {
+        throw new Error("No teams found");
+      }
+
+      return teams;
+    },
+  });
+};
+
+/**
+ * Query options for fetching a specific team by id.
+ */
+export const teamDetailQueryOptions = (teamId: string) => {
+  return queryOptions({
+    queryKey: teamQueryKeys.detail(teamId),
+    queryFn: async () => {
+      await sleep(100);
+      const team = mockApi.team.detail(teamId);
+      if (!team) {
+        throw new Error(`Team with id ${teamId} not found`);
+      }
+      return team;
+    },
+  });
+};

--- a/src/lib/queries/team.ts
+++ b/src/lib/queries/team.ts
@@ -22,12 +22,18 @@ export const teamListQueryOptions = () => {
     queryKey: teamQueryKeys.list(),
     queryFn: async () => {
       await sleep(100);
-      const teams = mockApi.team.list();
-      if (teams.length === 0) {
-        throw new Error("No teams found");
+      const response = mockApi.team.list();
+      if (!response.success) {
+        const { message, status } = response.error;
+        if (status === 404) {
+          return [];
+        }
+        if (status === 401) {
+          throw new Error("Unauthorized");
+        }
+        throw new Error(message);
       }
-
-      return teams;
+      return response.data;
     },
   });
 };
@@ -40,11 +46,15 @@ export const teamDetailQueryOptions = (teamId: string) => {
     queryKey: teamQueryKeys.detail(teamId),
     queryFn: async () => {
       await sleep(100);
-      const team = mockApi.team.detail(teamId);
-      if (!team) {
-        throw new Error(`Team with id ${teamId} not found`);
+      const response = mockApi.team.detail(teamId);
+      if (!response.success) {
+        const { message, status } = response.error;
+        if (status === 401) {
+          throw new Error("Unauthorized");
+        }
+        throw new Error(message);
       }
-      return team;
+      return response.data;
     },
   });
 };

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -1,0 +1,18 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { QueryClient } from "@tanstack/react-query";
+
+/*
+ We are only exposing the query client and query options to the rest of the app, instead of providing
+ reusable hooks like useStudyListQuery or only query keys like ["study", "list"].
+ Passing reusable query options lets us define a query’s key, function, and config in one place,
+ so we can use the same options for useQuery, prefetchQuery, or invalidateQueries.
+ This ensures cache keys and logic always match, reduces bugs, and makes refactoring easier.
+*/
+export const queryClient = new QueryClient();

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -6,7 +6,8 @@
 // SPDX-License-Identifier: MIT
 //
 
-import { QueryClient } from "@tanstack/react-query";
+import { toast } from "@stanfordspezi/spezi-web-design-system";
+import { QueryCache, QueryClient } from "@tanstack/react-query";
 
 /*
  We are only exposing the query client and query options to the rest of the app, instead of providing
@@ -15,4 +16,19 @@ import { QueryClient } from "@tanstack/react-query";
  so we can use the same options for useQuery, prefetchQuery, or invalidateQueries.
  This ensures cache keys and logic always match, reduces bugs, and makes refactoring easier.
 */
-export const queryClient = new QueryClient();
+export const queryClient = new QueryClient({
+  queryCache: new QueryCache({
+    onError: (error) => {
+      if (error.message === "Unauthorized") {
+        // Handle unauthorized errors globally by showing a toast that prompts the user to sign in again.
+        // This case is typically triggered when the user is authenticated but their session has expired.
+        toast.error("Your session has expired. Please sign in again.", {
+          duration: 5000,
+          // We reload the page to ensure that the navigation to the sign-in page
+          // is handled inside the beforeLoad hook of the layout route.
+          action: { label: "Sign in", onClick: () => window.location.reload() },
+        });
+      }
+    },
+  }),
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,16 +6,24 @@
 // SPDX-License-Identifier: MIT
 //
 
+import { QueryClientProvider } from "@tanstack/react-query";
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { queryClient } from "./lib/queryClient";
 import { routeTree } from "./routeTree.gen";
-
 import "./styles/index.css";
 
 const router = createRouter({
   basepath: "/spezi-web-study-platform", // This is necessary for GitHub Pages
   routeTree,
+  context: {
+    queryClient,
+  },
+  defaultPreload: "intent",
+  // Since we're using React Query, we don't want loader calls to ever be stale
+  // This will ensure that the loader is always called when the route is preloaded or visited
+  defaultPreloadStaleTime: 0,
 });
 
 declare module "@tanstack/react-router" {
@@ -29,7 +37,9 @@ if (rootElement && !rootElement.innerHTML) {
   const root = createRoot(rootElement);
   root.render(
     <StrictMode>
-      <RouterProvider router={router} />
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
     </StrictMode>,
   );
 }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -21,6 +21,7 @@
 // Import Routes
 
 import { Route as rootRoute } from './routes/~__root'
+import { Route as ErrorImport } from './routes/~error'
 import { Route as authSignInImport } from './routes/~(auth)/~sign-in'
 import { Route as dashboardIndexImport } from './routes/~(dashboard)/~index'
 import { Route as dashboardTeamStudyLayoutImport } from './routes/~(dashboard)/~$team/~$study/~layout'
@@ -31,6 +32,12 @@ import { Route as dashboardTeamStudyConfigurationImport } from './routes/~(dashb
 import { Route as dashboardTeamStudyIndexImport } from './routes/~(dashboard)/~$team/~$study/~index'
 
 // Create/Update Routes
+
+const ErrorRoute = ErrorImport.update({
+  id: '/error',
+  path: '/error',
+  getParentRoute: () => rootRoute,
+} as any)
 
 const authSignInRoute = authSignInImport.update({
   id: '/(auth)/sign-in',
@@ -86,6 +93,13 @@ const dashboardTeamStudyIndexRoute = dashboardTeamStudyIndexImport.update({
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/error': {
+      id: '/error'
+      path: '/error'
+      fullPath: '/error'
+      preLoaderRoute: typeof ErrorImport
+      parentRoute: typeof rootRoute
+    }
     '/(dashboard)/': {
       id: '/(dashboard)/'
       path: '/'
@@ -168,6 +182,7 @@ const dashboardTeamStudyLayoutRouteWithChildren =
   )
 
 export interface FileRoutesByFullPath {
+  '/error': typeof ErrorRoute
   '/': typeof dashboardIndexRoute
   '/sign-in': typeof authSignInRoute
   '/$team': typeof dashboardTeamIndexRoute
@@ -179,6 +194,7 @@ export interface FileRoutesByFullPath {
 }
 
 export interface FileRoutesByTo {
+  '/error': typeof ErrorRoute
   '/': typeof dashboardIndexRoute
   '/sign-in': typeof authSignInRoute
   '/$team': typeof dashboardTeamIndexRoute
@@ -190,6 +206,7 @@ export interface FileRoutesByTo {
 
 export interface FileRoutesById {
   __root__: typeof rootRoute
+  '/error': typeof ErrorRoute
   '/(dashboard)/': typeof dashboardIndexRoute
   '/(auth)/sign-in': typeof authSignInRoute
   '/(dashboard)/$team/': typeof dashboardTeamIndexRoute
@@ -203,6 +220,7 @@ export interface FileRoutesById {
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
+    | '/error'
     | '/'
     | '/sign-in'
     | '/$team'
@@ -213,6 +231,7 @@ export interface FileRouteTypes {
     | '/$team/$study/results'
   fileRoutesByTo: FileRoutesByTo
   to:
+    | '/error'
     | '/'
     | '/sign-in'
     | '/$team'
@@ -222,6 +241,7 @@ export interface FileRouteTypes {
     | '/$team/$study/results'
   id:
     | '__root__'
+    | '/error'
     | '/(dashboard)/'
     | '/(auth)/sign-in'
     | '/(dashboard)/$team/'
@@ -234,6 +254,7 @@ export interface FileRouteTypes {
 }
 
 export interface RootRouteChildren {
+  ErrorRoute: typeof ErrorRoute
   dashboardIndexRoute: typeof dashboardIndexRoute
   authSignInRoute: typeof authSignInRoute
   dashboardTeamIndexRoute: typeof dashboardTeamIndexRoute
@@ -241,6 +262,7 @@ export interface RootRouteChildren {
 }
 
 const rootRouteChildren: RootRouteChildren = {
+  ErrorRoute: ErrorRoute,
   dashboardIndexRoute: dashboardIndexRoute,
   authSignInRoute: authSignInRoute,
   dashboardTeamIndexRoute: dashboardTeamIndexRoute,
@@ -257,11 +279,15 @@ export const routeTree = rootRoute
     "__root__": {
       "filePath": "~__root.tsx",
       "children": [
+        "/error",
         "/(dashboard)/",
         "/(auth)/sign-in",
         "/(dashboard)/$team/",
         "/(dashboard)/$team/$study"
       ]
+    },
+    "/error": {
+      "filePath": "~error.tsx"
     },
     "/(dashboard)/": {
       "filePath": "~(dashboard)/~index.tsx"

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -22,6 +22,7 @@
 
 import { Route as rootRoute } from './routes/~__root'
 import { Route as ErrorImport } from './routes/~error'
+import { Route as dashboardLayoutImport } from './routes/~(dashboard)/~layout'
 import { Route as authSignInImport } from './routes/~(auth)/~sign-in'
 import { Route as dashboardIndexImport } from './routes/~(dashboard)/~index'
 import { Route as dashboardTeamStudyLayoutImport } from './routes/~(dashboard)/~$team/~$study/~layout'
@@ -39,6 +40,11 @@ const ErrorRoute = ErrorImport.update({
   getParentRoute: () => rootRoute,
 } as any)
 
+const dashboardLayoutRoute = dashboardLayoutImport.update({
+  id: '/(dashboard)',
+  getParentRoute: () => rootRoute,
+} as any)
+
 const authSignInRoute = authSignInImport.update({
   id: '/(auth)/sign-in',
   path: '/sign-in',
@@ -46,21 +52,21 @@ const authSignInRoute = authSignInImport.update({
 } as any)
 
 const dashboardIndexRoute = dashboardIndexImport.update({
-  id: '/(dashboard)/',
+  id: '/',
   path: '/',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => dashboardLayoutRoute,
 } as any)
 
 const dashboardTeamStudyLayoutRoute = dashboardTeamStudyLayoutImport.update({
-  id: '/(dashboard)/$team/$study',
+  id: '/$team/$study',
   path: '/$team/$study',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => dashboardLayoutRoute,
 } as any)
 
 const dashboardTeamIndexRoute = dashboardTeamIndexImport.update({
-  id: '/(dashboard)/$team/',
+  id: '/$team/',
   path: '/$team/',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => dashboardLayoutRoute,
 } as any)
 
 const dashboardTeamStudyResultsRoute = dashboardTeamStudyResultsImport.update({
@@ -93,6 +99,13 @@ const dashboardTeamStudyIndexRoute = dashboardTeamStudyIndexImport.update({
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/(dashboard)': {
+      id: '/(dashboard)'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof dashboardLayoutImport
+      parentRoute: typeof rootRoute
+    }
     '/error': {
       id: '/error'
       path: '/error'
@@ -105,7 +118,7 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof dashboardIndexImport
-      parentRoute: typeof rootRoute
+      parentRoute: typeof dashboardLayoutImport
     }
     '/(auth)/sign-in': {
       id: '/(auth)/sign-in'
@@ -119,14 +132,14 @@ declare module '@tanstack/react-router' {
       path: '/$team'
       fullPath: '/$team'
       preLoaderRoute: typeof dashboardTeamIndexImport
-      parentRoute: typeof rootRoute
+      parentRoute: typeof dashboardLayoutImport
     }
     '/(dashboard)/$team/$study': {
       id: '/(dashboard)/$team/$study'
       path: '/$team/$study'
       fullPath: '/$team/$study'
       preLoaderRoute: typeof dashboardTeamStudyLayoutImport
-      parentRoute: typeof rootRoute
+      parentRoute: typeof dashboardLayoutImport
     }
     '/(dashboard)/$team/$study/': {
       id: '/(dashboard)/$team/$study/'
@@ -181,9 +194,25 @@ const dashboardTeamStudyLayoutRouteWithChildren =
     dashboardTeamStudyLayoutRouteChildren,
   )
 
+interface dashboardLayoutRouteChildren {
+  dashboardIndexRoute: typeof dashboardIndexRoute
+  dashboardTeamIndexRoute: typeof dashboardTeamIndexRoute
+  dashboardTeamStudyLayoutRoute: typeof dashboardTeamStudyLayoutRouteWithChildren
+}
+
+const dashboardLayoutRouteChildren: dashboardLayoutRouteChildren = {
+  dashboardIndexRoute: dashboardIndexRoute,
+  dashboardTeamIndexRoute: dashboardTeamIndexRoute,
+  dashboardTeamStudyLayoutRoute: dashboardTeamStudyLayoutRouteWithChildren,
+}
+
+const dashboardLayoutRouteWithChildren = dashboardLayoutRoute._addFileChildren(
+  dashboardLayoutRouteChildren,
+)
+
 export interface FileRoutesByFullPath {
-  '/error': typeof ErrorRoute
   '/': typeof dashboardIndexRoute
+  '/error': typeof ErrorRoute
   '/sign-in': typeof authSignInRoute
   '/$team': typeof dashboardTeamIndexRoute
   '/$team/$study': typeof dashboardTeamStudyLayoutRouteWithChildren
@@ -206,6 +235,7 @@ export interface FileRoutesByTo {
 
 export interface FileRoutesById {
   __root__: typeof rootRoute
+  '/(dashboard)': typeof dashboardLayoutRouteWithChildren
   '/error': typeof ErrorRoute
   '/(dashboard)/': typeof dashboardIndexRoute
   '/(auth)/sign-in': typeof authSignInRoute
@@ -220,8 +250,8 @@ export interface FileRoutesById {
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
-    | '/error'
     | '/'
+    | '/error'
     | '/sign-in'
     | '/$team'
     | '/$team/$study'
@@ -241,6 +271,7 @@ export interface FileRouteTypes {
     | '/$team/$study/results'
   id:
     | '__root__'
+    | '/(dashboard)'
     | '/error'
     | '/(dashboard)/'
     | '/(auth)/sign-in'
@@ -254,19 +285,15 @@ export interface FileRouteTypes {
 }
 
 export interface RootRouteChildren {
+  dashboardLayoutRoute: typeof dashboardLayoutRouteWithChildren
   ErrorRoute: typeof ErrorRoute
-  dashboardIndexRoute: typeof dashboardIndexRoute
   authSignInRoute: typeof authSignInRoute
-  dashboardTeamIndexRoute: typeof dashboardTeamIndexRoute
-  dashboardTeamStudyLayoutRoute: typeof dashboardTeamStudyLayoutRouteWithChildren
 }
 
 const rootRouteChildren: RootRouteChildren = {
+  dashboardLayoutRoute: dashboardLayoutRouteWithChildren,
   ErrorRoute: ErrorRoute,
-  dashboardIndexRoute: dashboardIndexRoute,
   authSignInRoute: authSignInRoute,
-  dashboardTeamIndexRoute: dashboardTeamIndexRoute,
-  dashboardTeamStudyLayoutRoute: dashboardTeamStudyLayoutRouteWithChildren,
 }
 
 export const routeTree = rootRoute
@@ -279,9 +306,15 @@ export const routeTree = rootRoute
     "__root__": {
       "filePath": "~__root.tsx",
       "children": [
+        "/(dashboard)",
         "/error",
+        "/(auth)/sign-in"
+      ]
+    },
+    "/(dashboard)": {
+      "filePath": "~(dashboard)/~layout.tsx",
+      "children": [
         "/(dashboard)/",
-        "/(auth)/sign-in",
         "/(dashboard)/$team/",
         "/(dashboard)/$team/$study"
       ]
@@ -290,16 +323,19 @@ export const routeTree = rootRoute
       "filePath": "~error.tsx"
     },
     "/(dashboard)/": {
-      "filePath": "~(dashboard)/~index.tsx"
+      "filePath": "~(dashboard)/~index.tsx",
+      "parent": "/(dashboard)"
     },
     "/(auth)/sign-in": {
       "filePath": "~(auth)/~sign-in.tsx"
     },
     "/(dashboard)/$team/": {
-      "filePath": "~(dashboard)/~$team/~index.tsx"
+      "filePath": "~(dashboard)/~$team/~index.tsx",
+      "parent": "/(dashboard)"
     },
     "/(dashboard)/$team/$study": {
       "filePath": "~(dashboard)/~$team/~$study/~layout.tsx",
+      "parent": "/(dashboard)",
       "children": [
         "/(dashboard)/$team/$study/",
         "/(dashboard)/$team/$study/configuration",

--- a/src/routes/~(auth)/~sign-in.tsx
+++ b/src/routes/~(auth)/~sign-in.tsx
@@ -6,12 +6,59 @@
 // SPDX-License-Identifier: MIT
 //
 
-import { createFileRoute } from "@tanstack/react-router";
+import { Button } from "@stanfordspezi/spezi-web-design-system";
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { z } from "zod";
+import { mockApi } from "@/lib/mockApi";
+import { currentUserQueryOptions } from "@/lib/queries/currentUser";
+import { queryClient } from "@/lib/queryClient";
 
 const SignInComponent = () => {
-  return <div>Sign in Route</div>;
+  const search = Route.useSearch();
+  const navigate = Route.useNavigate();
+
+  const handleSignIn = async () => {
+    mockApi.auth.signIn();
+    await navigate({ to: search.redirect ?? "/" });
+  };
+
+  return (
+    <div className="flex-center size-full flex-col">
+      <h1 className="text-text pb-4 text-lg">Sign into the study platform</h1>
+      <Button onClick={handleSignIn}>Sign in</Button>
+    </div>
+  );
 };
 
 export const Route = createFileRoute("/(auth)/sign-in")({
   component: SignInComponent,
+  validateSearch: z.object({
+    redirect: z.string().optional(),
+  }),
+  beforeLoad: async ({ search }) => {
+    try {
+      // Check if the user is already authenticated
+      // if so, redirect them to the specified path or home
+      await queryClient.ensureQueryData(currentUserQueryOptions());
+      return redirect({ to: search.redirect ?? "/" });
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message === "Unauthorized") {
+          // User is not authenticated, allow the sign-in page to load.
+          return;
+        }
+      }
+
+      console.error("Error checking authentication status:", error);
+
+      const message =
+        error instanceof Error ?
+          error.message
+        : "An unexpected error occurred while checking authentication status";
+      return redirect({
+        to: "/error",
+        search: { message },
+      });
+    }
+  },
 });

--- a/src/routes/~(dashboard)/~$team/~$study/~layout.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~layout.tsx
@@ -25,10 +25,15 @@ export const Route = createFileRoute("/(dashboard)/$team/$study")({
     try {
       // We validate that the `params.team` and `params.study` exist before
       // loading the dashboard, so we can redirect to the error page if they don't.
-      await Promise.all([
-        queryClient.ensureQueryData(teamDetailQueryOptions(params.team)),
-        queryClient.ensureQueryData(studyDetailQueryOptions(params.study)),
+      const [teamData, studyData] = await Promise.all([
+        queryClient.fetchQuery(teamDetailQueryOptions(params.team)),
+        queryClient.fetchQuery(studyDetailQueryOptions(params.study)),
       ]);
+      if (studyData.teamId !== teamData.id) {
+        throw new Error(
+          `Study ${params.study} does not belong to team ${params.team}.`,
+        );
+      }
     } catch (error) {
       console.error(
         `Error ensuring query data for team ${params.team} and study ${params.study}:`,

--- a/src/routes/~(dashboard)/~$team/~$study/~layout.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~layout.tsx
@@ -44,7 +44,7 @@ export const Route = createFileRoute("/(dashboard)/$team/$study")({
         error instanceof Error ?
           error.message
         : `Error ensuring query data for team ${params.team} and study ${params.study}`;
-      throw redirect({
+      return redirect({
         to: "/error",
         search: { message },
       });

--- a/src/routes/~(dashboard)/~$team/~index.tsx
+++ b/src/routes/~(dashboard)/~$team/~index.tsx
@@ -7,15 +7,49 @@
 //
 
 import { createFileRoute, redirect } from "@tanstack/react-router";
+import { studyListQueryOptions } from "@/lib/queries/study";
+import { teamDetailQueryOptions } from "@/lib/queries/team";
 
+/*
+ Redirect them to the first available study in their team.
+ */
 export const Route = createFileRoute("/(dashboard)/$team/")({
-  beforeLoad: () => {
-    throw redirect({
-      to: "/$team/$study",
-      params: {
-        team: "team-pine",
-        study: "activity-study",
-      },
-    });
+  beforeLoad: async ({ context: { queryClient }, params }) => {
+    try {
+      // We validate that the `params.team` exists, so we can throw a more
+      // meaningful error if it doesn't.
+      await queryClient.ensureQueryData(teamDetailQueryOptions(params.team));
+
+      const studies = await queryClient.fetchQuery(
+        studyListQueryOptions({ teamId: params.team }),
+      );
+      const firstStudy = studies.at(0);
+
+      if (!firstStudy) {
+        throw new Error(`No studies found for team ${params.team}`);
+      }
+
+      return redirect({
+        to: "/$team/$study",
+        params: {
+          team: params.team,
+          study: firstStudy.id,
+        },
+      });
+    } catch (error) {
+      console.error(
+        `Error redirecting to a study for team ${params.team}:`,
+        error,
+      );
+
+      const message =
+        error instanceof Error ?
+          error.message
+        : `Error redirecting to a study for team ${params.team}`;
+      return redirect({
+        to: "/error",
+        search: { message },
+      });
+    }
   },
 });

--- a/src/routes/~(dashboard)/~index.tsx
+++ b/src/routes/~(dashboard)/~index.tsx
@@ -7,15 +7,52 @@
 //
 
 import { createFileRoute, redirect } from "@tanstack/react-router";
+import { studyListQueryOptions } from "@/lib/queries/study";
+import { teamListQueryOptions } from "@/lib/queries/team";
 
+/*
+ If a user lands on the root path, we want to redirect them to the
+ first team and study they have access to. If they have no teams or studies,
+ we redirect them to an error page for now. In the future this will route to
+ a "create team" or "create study" page.
+ */
 export const Route = createFileRoute("/(dashboard)/")({
-  beforeLoad: () => {
-    throw redirect({
-      to: "/$team/$study",
-      params: {
-        team: "team-pine",
-        study: "activity-study",
-      },
-    });
+  beforeLoad: async ({ context: { queryClient } }) => {
+    try {
+      const teams = await queryClient.fetchQuery(teamListQueryOptions());
+      const firstTeam = teams.at(0);
+
+      if (!firstTeam) {
+        throw new Error("No teams found");
+      }
+
+      const studies = await queryClient.fetchQuery(
+        studyListQueryOptions({ teamId: firstTeam.id }),
+      );
+      const firstStudy = studies.at(0);
+
+      if (!firstStudy) {
+        throw new Error(`No studies found for team ${firstTeam.id}`);
+      }
+
+      return redirect({
+        to: "/$team/$study",
+        params: {
+          team: firstTeam.id,
+          study: firstStudy.id,
+        },
+      });
+    } catch (error) {
+      console.error("Error redirecting to a team and study:", error);
+
+      const message =
+        error instanceof Error ?
+          error.message
+        : "Error redirecting to a team and study";
+      return redirect({
+        to: "/error",
+        search: { message },
+      });
+    }
   },
 });

--- a/src/routes/~(dashboard)/~layout.tsx
+++ b/src/routes/~(dashboard)/~layout.tsx
@@ -1,0 +1,33 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { currentUserQueryOptions } from "@/lib/queries/currentUser";
+
+// This layout route is used to ensure that the user is authenticated
+// before accessing the dashboard.
+export const Route = createFileRoute("/(dashboard)")({
+  beforeLoad: async ({ context: { queryClient }, location }) => {
+    try {
+      await queryClient.ensureQueryData(currentUserQueryOptions());
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message === "Unauthorized") {
+          // User is not authenticated, allow the sign-in page to load.
+          return redirect({
+            to: "/sign-in",
+            search: { redirect: location.href },
+          });
+        }
+      }
+
+      console.error("Error checking authentication status:", error);
+
+      const message =
+        error instanceof Error ?
+          error.message
+        : "An unexpected error occurred while checking authentication status";
+      return redirect({
+        to: "/error",
+        search: { message },
+      });
+    }
+  },
+});

--- a/src/routes/~__root.tsx
+++ b/src/routes/~__root.tsx
@@ -7,6 +7,7 @@
 //
 
 import { SpeziProvider } from "@stanfordspezi/spezi-web-design-system";
+import type { QueryClient } from "@tanstack/react-query";
 import {
   createRootRouteWithContext,
   HeadContent,
@@ -14,6 +15,10 @@ import {
   Outlet,
 } from "@tanstack/react-router";
 import type { ComponentProps } from "react";
+
+export interface RouterAppContext {
+  queryClient: QueryClient;
+}
 
 const routerProps: ComponentProps<typeof SpeziProvider>["router"] = {
   Link: ({ href, ...props }) => <Link to={href} {...props} />,
@@ -32,7 +37,7 @@ const RootComponent = () => {
   );
 };
 
-export const Route = createRootRouteWithContext()({
+export const Route = createRootRouteWithContext<RouterAppContext>()({
   component: RootComponent,
   head: () => ({
     meta: [

--- a/src/routes/~error.tsx
+++ b/src/routes/~error.tsx
@@ -1,0 +1,31 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { createFileRoute } from "@tanstack/react-router";
+
+const ErrorRoute = () => {
+  const { message } = Route.useSearch();
+  return (
+    <div className="flex-center size-full flex-col">
+      <h1 className="text-text">Error</h1>
+      <p>{message}</p>
+    </div>
+  );
+};
+
+export const Route = createFileRoute("/error")({
+  component: ErrorRoute,
+  validateSearch: (search) => {
+    return {
+      message:
+        search.message && typeof search.message === "string" ?
+          search.message
+        : "An unexpected error occurred",
+    };
+  },
+});

--- a/src/routes/~error.tsx
+++ b/src/routes/~error.tsx
@@ -7,6 +7,7 @@
 //
 
 import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
 
 const ErrorRoute = () => {
   const { message } = Route.useSearch();
@@ -20,12 +21,7 @@ const ErrorRoute = () => {
 
 export const Route = createFileRoute("/error")({
   component: ErrorRoute,
-  validateSearch: (search) => {
-    return {
-      message:
-        search.message && typeof search.message === "string" ?
-          search.message
-        : "An unexpected error occurred",
-    };
-  },
+  validateSearch: z.object({
+    message: z.string().optional().catch("An unexpected error occurred"),
+  }),
 });

--- a/src/utils/createMockApi.ts
+++ b/src/utils/createMockApi.ts
@@ -1,0 +1,109 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+export class MockApiError extends Error {
+  status: number;
+
+  constructor(message: string, status = 400) {
+    super(message);
+    this.name = "MockApiError";
+    this.status = status;
+  }
+}
+
+interface DatabaseSuccessResponse<T> {
+  success: true;
+  data: T;
+  error: never;
+}
+interface DatabaseErrorResponse {
+  success: false;
+  data: never;
+  error: {
+    message: string;
+    status: number;
+  };
+}
+export type DatabaseResponse<T> =
+  | DatabaseSuccessResponse<T>
+  | DatabaseErrorResponse;
+
+/**
+ * Creates a mock API object based on the provided handler functions.
+ *
+ * This utility takes an object of handler groups, where each group contains methods
+ * that simulate API endpoints. Each method is wrapped to return a standardized
+ * `DatabaseResponse` object, capturing both successful results and errors.
+ *
+ * @example
+ * ```typescript
+ * const handlers = {
+ *   user: {
+ *     getUser: (id: string) => ({ id, name: "Alice" }),
+ *   },
+ * };
+ * const api = createMockApi(handlers);
+ * const response = api.user.getUser("123");
+ * // response: { success: true, data: { id: "123", name: "Alice" }, error: undefined }
+ * ```
+ */
+export const createMockApi = <
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  T extends Record<string, Record<string, (...args: any[]) => any>>,
+>(
+  handlers: T,
+): {
+  [Group in keyof T]: {
+    [Method in keyof T[Group]]: (
+      ...args: Parameters<T[Group][Method]>
+    ) => DatabaseResponse<ReturnType<T[Group][Method]>>;
+  };
+} => {
+  // create an empty api object whose shape matches handlers
+  const api = {} as {
+    [Group in keyof T]: {
+      [Method in keyof T[Group]]: (
+        ...args: Parameters<T[Group][Method]>
+      ) => DatabaseResponse<ReturnType<T[Group][Method]>>;
+    };
+  };
+
+  for (const groupKey of Object.keys(handlers) as Array<keyof T>) {
+    // force‐cast here so TS knows api[groupKey] exists
+    api[groupKey] = {} as (typeof api)[typeof groupKey];
+
+    const groupHandlers = handlers[groupKey];
+    for (const methodKey of Object.keys(groupHandlers) as Array<
+      keyof T[typeof groupKey]
+    >) {
+      const originalFn = groupHandlers[methodKey];
+      // wrap the raw handler
+      api[groupKey][methodKey] = ((...args) => {
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          const data = originalFn(...args);
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          return { success: true, data, error: undefined as never };
+        } catch (err: unknown) {
+          const message =
+            err instanceof MockApiError ? err.message : String(err);
+          const status = err instanceof MockApiError ? err.status : 400;
+          return {
+            success: false,
+            data: undefined as never,
+            error: { message, status },
+          };
+        }
+      }) as (
+        ...args: Parameters<typeof originalFn>
+      ) => DatabaseResponse<ReturnType<typeof originalFn>>;
+    }
+  }
+
+  return api;
+};

--- a/src/utils/queryKeysFactory.ts
+++ b/src/utils/queryKeysFactory.ts
@@ -1,0 +1,81 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+export interface TQueryKey<TKey, TListQuery = unknown, TDetailQuery = string> {
+  all: readonly [TKey];
+  /**
+   * This is typically only used for invalidations to invalidate all queries
+   * related to filtered or queried lists
+   */
+  lists: () => readonly [...TQueryKey<TKey>["all"], "list"];
+  /**
+   * This is typically used in useQuery to fetch a list of items
+   * e.g. a list of studies or teams
+   */
+  list: (
+    query?: TListQuery,
+  ) => readonly [
+    ...ReturnType<TQueryKey<TKey>["lists"]>,
+    { query: TListQuery | undefined },
+  ];
+  /**
+   * This is typically only used for invalidations to invalidate all queries
+   * related to details queries regardless of any filters or particular items.
+   * This is not used that often.
+   */
+  details: () => readonly [...TQueryKey<TKey>["all"], "detail"];
+  /**
+   * This is typically used in useQuery to fetch a single item
+   * e.g. a single study or team
+   */
+  detail: (
+    id: TDetailQuery,
+    query?: TListQuery,
+  ) => readonly [
+    ...ReturnType<TQueryKey<TKey>["details"]>,
+    TDetailQuery,
+    { query: TListQuery | undefined },
+  ];
+}
+
+/**
+ * Factory function to generate standardized query key objects for use with React Query.
+ * This is the recommended way to create query keys in a consistent manner.
+ * Implementation inspired by {@link https://github.com/medusajs/b2b-starter-medusa/blob/main/backend/src/admin/lib/query-key-factory.ts Medusa.JS}.
+ *
+ * @see {@link https://tkdodo.eu/blog/effective-react-query-keys#use-query-key-factories Effective React Query Keys}
+ * @example
+ * ```typescript
+ * const userQueryKeys = queryKeysFactory('user');
+ * userQueryKeys.all; // ['user']
+ * userQueryKeys.lists(); // ['user', 'list']
+ * userQueryKeys.list({ page: 1 }); // ['user', 'list', { query: { page: 1 } }]
+ * userQueryKeys.details(); // ['user', 'detail']
+ * userQueryKeys.detail('123', { active: true }); // ['user', 'detail', '123', { query: { active: true } }]
+ * ```
+ */
+export const queryKeysFactory = <
+  T,
+  TListQueryType = unknown,
+  TDetailQueryType = string,
+>(
+  globalKey: T,
+) => {
+  const queryKeyFactory: TQueryKey<T, TListQueryType, TDetailQueryType> = {
+    all: [globalKey],
+    lists: () => [...queryKeyFactory.all, "list"],
+    list: (query?: TListQueryType) => [...queryKeyFactory.lists(), { query }],
+    details: () => [...queryKeyFactory.all, "detail"],
+    detail: (id: TDetailQueryType, query?: TListQueryType) => [
+      ...queryKeyFactory.details(),
+      id,
+      { query },
+    ],
+  };
+  return queryKeyFactory;
+};


### PR DESCRIPTION
# Add mock auth and sign in flow

![542shots_so](https://github.com/user-attachments/assets/93278366-5348-4dbf-a145-7306b59633a9)

## :recycle: Current situation & Problem
There is currently no auth logic, components and pages. This PR creates endpoints for sign-in, sign-out and getting the current user on the mockApi. It also creates the necessary components and adjustments to handle the sign-in and sign-out flows. The PR does _not_ contain any major styling of the sign in flow. This will come in a follow up PR.

## :gear: Release Notes

### Auth and Mock API:

* **Mock Database**: Introduced mock data for users, including roles such as "admin" and "user". The current user is dynamically set during authentication flows to simulate different user states.
* **Mock API**:  Add a `⁠createMockApi` function to simulate backend interactions. This utility wraps handler functions to return standardized ⁠`DatabaseResponse` objects, capturing both successful results and errors.
* **Mock Authentication**: Implemented a mock authentication system to simulate user sign-in and sign-out flows.
* **Routing**: Updated routing to redirect users based on authentication status.

### Component Refactoring:

* **User Dropdown**: Updated the `UserDropdown` component to fetch the current user dynamically and handle sign-out using the mock API.
* **Navigation Links**: Modified main navigation links to handle warnings when redirecting after signing out.

### Dependency Updates:

* Added `zod` for validating a route's search params.

## :white_check_mark: Testing
* Added new end-to-end tests to verify authentication flows, including sign-in redirection, persistence of auth state, and behavior after logout.
* Adjusted the other tests to properly authenticate before starting the test.
* Developed Playwright fixtures for improving authentication flows and page navigation.

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).