### PR TITLE
Closes #39: Simplify header code

### DIFF
--- a/src/components/interfaces/Header/Notifications.tsx
+++ b/src/components/interfaces/Header/Notifications.tsx
@@ -22,9 +22,10 @@ export const Notifications = () => {
     <Sheet>
       <SheetTrigger asChild>
         <Button
+          size={null}
           variant="ghost"
           aria-label="Notifications"
-          className="size-8! p-0!"
+          className="size-8 rounded-md p-0"
         >
           <Bell className="size-4" />
         </Button>

--- a/src/components/interfaces/Header/UserAvatar.tsx
+++ b/src/components/interfaces/Header/UserAvatar.tsx
@@ -37,8 +37,9 @@ export const UserAvatar = ({
       )}
     >
       <Avatar
+        size={null}
         className={cn(
-          "bg-surface border-border-secondary size-(--avatar-size)! rounded-full border bg-clip-padding p-0.5 shadow-xs",
+          "bg-surface border-border-secondary size-(--avatar-size) rounded-full border bg-clip-padding p-0.5 shadow-xs",
           className,
         )}
         src={user.imageUrl}

--- a/src/components/layouts/DashboardLayout.tsx
+++ b/src/components/layouts/DashboardLayout.tsx
@@ -17,7 +17,7 @@ interface DashboardLayoutProps {
 
 export const DashboardLayout = ({ children }: DashboardLayoutProps) => {
   return (
-    <div className="[--header-height:calc(--spacing(14))]">
+    <div className="[--header-height:--spacing(14)]">
       <SidebarProvider className="flex flex-col">
         <Header />
         <div className="flex flex-1">


### PR DESCRIPTION
# Simplify header code

## :recycle: Current situation & Problem
Some parts of the header code are unnecessarily complex.

## :gear: Release Notes
* Added `size={null}` to header `<Button />` and the `<Avatar />` to ensure size is explicitly unset. Removed the `!important` overrides. 
* Simplified the `--header-height` CSS variable by removing the `calc()` function and directly referencing `--spacing(14)`.

## :white_check_mark: Testing
No visual or logic changes. Tested manually.

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).