### PR TITLE
Closes #45: Adjust sidebar to handle route groups with children

### DIFF
--- a/src/components/interfaces/Sidebar/MainNav.tsx
+++ b/src/components/interfaces/Sidebar/MainNav.tsx
@@ -24,6 +24,9 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
 } from "./Sidebar";
 
 interface NavBarItem {
@@ -31,6 +34,7 @@ interface NavBarItem {
   title: string;
   linkOptions?: ValidateLinkOptions;
   icon?: LucideIcon;
+  subMenu?: NavBarItem[];
 }
 
 const navBarItems: NavBarItem[] = [
@@ -50,6 +54,20 @@ const navBarItems: NavBarItem[] = [
     title: "Configuration",
     icon: Bolt,
     linkOptions: { to: "/$team/$study/configuration" },
+    subMenu: [
+      {
+        id: "basic-information",
+        title: "Basic Information",
+      },
+      {
+        id: "enrollment",
+        title: "Enrollment",
+      },
+      {
+        id: "components",
+        title: "Components",
+      },
+    ],
   },
   {
     id: "participants",
@@ -65,11 +83,18 @@ const navBarItems: NavBarItem[] = [
   },
 ];
 
-const MainNavButton = ({ item }: { item: NavBarItem }) => {
+const MainNavButton = ({
+  item,
+  isSubMenu,
+}: {
+  item: NavBarItem;
+  isSubMenu?: boolean;
+}) => {
   const matchRoute = useMatchRoute();
+  const Comp = isSubMenu ? SidebarMenuSubButton : SidebarMenuButton;
   if (item.linkOptions) {
     return (
-      <SidebarMenuButton
+      <Comp
         asChild
         tooltip={item.title}
         isActive={!!matchRoute({ to: item.linkOptions.to })}
@@ -78,15 +103,15 @@ const MainNavButton = ({ item }: { item: NavBarItem }) => {
           {item.icon && <item.icon />}
           <span>{item.title}</span>
         </Link>
-      </SidebarMenuButton>
+      </Comp>
     );
   }
 
   return (
-    <SidebarMenuButton tooltip={item.title}>
+    <Comp tooltip={item.title}>
       {item.icon && <item.icon />}
       <span>{item.title}</span>
-    </SidebarMenuButton>
+    </Comp>
   );
 };
 
@@ -97,6 +122,15 @@ export const MainNav = () => {
         {navBarItems.map((item) => (
           <SidebarMenuItem key={item.id}>
             <MainNavButton item={item} />
+            {item.subMenu && (
+              <SidebarMenuSub>
+                {item.subMenu.map((subItem) => (
+                  <SidebarMenuSubItem key={subItem.id}>
+                    <MainNavButton item={subItem} isSubMenu />
+                  </SidebarMenuSubItem>
+                ))}
+              </SidebarMenuSub>
+            )}
           </SidebarMenuItem>
         ))}
       </SidebarMenu>

--- a/src/components/interfaces/Sidebar/Sidebar.tsx
+++ b/src/components/interfaces/Sidebar/Sidebar.tsx
@@ -541,7 +541,14 @@ const SidebarMenuButton = ({
       data-sidebar="menu-button"
       data-size={size}
       data-active={isActive}
-      className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
+      className={cn(
+        sidebarMenuButtonVariants({ variant, size }),
+        // When collapsed, show active state if any descendant sub-item is active
+        "group-data-[collapsible=icon]:group-has-[[data-sidebar=menu-sub-button][data-active=true]]/menu-item:bg-fill",
+        "group-data-[collapsible=icon]:group-has-[[data-sidebar=menu-sub-button][data-active=true]]/menu-item:border",
+        "group-data-[collapsible=icon]:group-has-[[data-sidebar=menu-sub-button][data-active=true]]/menu-item:shadow-xs",
+        className,
+      )}
       {...props}
     />
   );
@@ -656,7 +663,7 @@ const SidebarMenuSub = ({ className, ...props }: ComponentProps<"ul">) => {
       data-slot="sidebar-menu-sub"
       data-sidebar="menu-sub"
       className={cn(
-        "border-border mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l px-2.5 py-0.5",
+        "border-border-secondary mt-1.5 ml-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l pl-2.5",
         "group-data-[collapsible=icon]:hidden",
         className,
       )}
@@ -678,16 +685,16 @@ const SidebarMenuSubItem = ({ className, ...props }: ComponentProps<"li">) => {
 
 const SidebarMenuSubButton = ({
   asChild = false,
-  size = "md",
   isActive = false,
+  variant = "default",
+  size = "default",
   className,
   ...props
-}: ComponentProps<"a"> & {
+}: ComponentProps<"button"> & {
   asChild?: boolean;
-  size?: "sm" | "md";
   isActive?: boolean;
-}) => {
-  const Comp = asChild ? Slot : "a";
+} & VariantProps<typeof sidebarMenuButtonVariants>) => {
+  const Comp = asChild ? Slot : "button";
 
   return (
     <Comp
@@ -696,10 +703,8 @@ const SidebarMenuSubButton = ({
       data-size={size}
       data-active={isActive}
       className={cn(
-        "ring-border-secondary hover:bg-bg-hover active:bg-fill [&>svg]:text-text-secondary flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
-        "data-[active=true]:bg-fill data-[active=true]:text-text-secondary",
-        size === "sm" && "text-xs",
-        size === "md" && "text-sm",
+        sidebarMenuButtonVariants({ variant, size }),
+        "text-text-tertiary",
         "group-data-[collapsible=icon]:hidden",
         className,
       )}


### PR DESCRIPTION
# Adjust sidebar to handle route groups with children

<img width="1610" height="1126" alt="enhanced_895shots_so (2)" src="https://github.com/user-attachments/assets/eee25911-7f5f-41ca-b410-e78964f5fa0e" />

## :recycle: Current situation & Problem
Currently, the sidebar only supports one level.

## :gear: Release Notes
* Added `subMenu` property to the `NavBarItem` interface and updated `navBarItems` to include submenu items for the "Configuration" section.
* Updated the `MainNav` component to render `SidebarMenuSub` and `SidebarMenuSubItem` for items with submenus.

* Refined `SidebarMenuButton` to include active state styling for collapsed views with active submenu items.
* Adjusted `SidebarMenuSub` styling for improved spacing and alignment.
* Updated `SidebarMenuSubButton` to use consistent variants and sizes, aligning with the main button styling. 

## :white_check_mark: Testing
Manually tested since the changes were mostly related to styles.

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).