### PR TITLE
Closes #56: Add scroll padding to the page

### DIFF
--- a/src/components/interfaces/Header/Header.tsx
+++ b/src/components/interfaces/Header/Header.tsx
@@ -18,7 +18,7 @@ export const Header = () => {
     <header
       className={cn(
         "fixed top-0 z-10",
-        "flex h-14 w-full items-center justify-between gap-2 pr-3 pl-2",
+        "flex h-(--header-height) w-full items-center justify-between gap-2 pr-3 pl-2",
         "bg-bg-secondary border-border-secondary border-b",
       )}
     >

--- a/src/components/layouts/DashboardLayout.tsx
+++ b/src/components/layouts/DashboardLayout.tsx
@@ -17,16 +17,12 @@ interface DashboardLayoutProps {
 
 export const DashboardLayout = ({ children }: DashboardLayoutProps) => {
   return (
-    <div className="[--header-height:--spacing(14)]">
-      <SidebarProvider className="flex flex-col">
-        <Header />
-        <div className="flex flex-1">
-          <AppSidebar className="top-(--header-height) !h-[calc(100svh-var(--header-height))]" />
-          <SidebarInset className="pt-(--header-height)">
-            {children}
-          </SidebarInset>
-        </div>
-      </SidebarProvider>
-    </div>
+    <SidebarProvider className="flex flex-col">
+      <Header />
+      <div className="flex flex-1">
+        <AppSidebar className="top-(--header-height) !h-[calc(100svh-var(--header-height))]" />
+        <SidebarInset className="pt-(--header-height)">{children}</SidebarInset>
+      </div>
+    </SidebarProvider>
   );
 };

--- a/src/components/ui/RouteHeader.tsx
+++ b/src/components/ui/RouteHeader.tsx
@@ -47,6 +47,7 @@ export const RouteHeader = ({
 
   return (
     <div
+      ref={headerRef}
       className={cn(
         "bg-bg/80 sticky top-(--header-height) backdrop-blur-md transition-shadow duration-200",
         isScrolled && "shadow-lg shadow-black/2",

--- a/src/components/ui/RouteHeader.tsx
+++ b/src/components/ui/RouteHeader.tsx
@@ -9,11 +9,17 @@
 import { cn } from "@stanfordspezi/spezi-web-design-system";
 import { createLink, type LinkComponentProps } from "@tanstack/react-router";
 import { ArrowLeft } from "lucide-react";
-import { type ComponentProps, type ReactNode } from "react";
+import {
+  useRef,
+  type ComponentProps,
+  type ReactNode,
+  type RefObject,
+} from "react";
+import { useResizeObserver } from "usehooks-ts";
 import { useIsScrolled } from "@/utils/useIsScrolled";
 import { DashedSeparator } from "./DashedSeparator";
 
-interface RouteHeaderProps extends Pick<ComponentProps<"div">, "ref"> {
+interface RouteHeaderProps {
   title: ReactNode;
   description: ReactNode;
   accessoryLeft?: ReactNode;
@@ -21,16 +27,26 @@ interface RouteHeaderProps extends Pick<ComponentProps<"div">, "ref"> {
 }
 
 export const RouteHeader = ({
-  ref,
   title,
   description,
   accessoryLeft,
   accessoryRight,
 }: RouteHeaderProps) => {
   const isScrolled = useIsScrolled();
+  const headerRef = useRef<HTMLDivElement>(null);
+
+  useResizeObserver({
+    ref: headerRef as RefObject<HTMLDivElement>,
+    onResize: ({ height = 0 }) => {
+      document.documentElement.style.setProperty(
+        "--route-header-height",
+        `${height}px`,
+      );
+    },
+  });
+
   return (
     <div
-      ref={ref}
       className={cn(
         "bg-bg/80 sticky top-(--header-height) backdrop-blur-md transition-shadow duration-200",
         isScrolled && "shadow-lg shadow-black/2",

--- a/src/routes/~(dashboard)/~$team/~$study/~configuration/components/BasicInfoLayout.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~configuration/components/BasicInfoLayout.tsx
@@ -7,13 +7,7 @@
 //
 
 import { Button } from "@stanfordspezi/spezi-web-design-system";
-import {
-  useRef,
-  type CSSProperties,
-  type ReactNode,
-  type RefObject,
-} from "react";
-import { useResizeObserver } from "usehooks-ts";
+import { type ReactNode } from "react";
 import { RouteHeader, RouteHeaderBackLink } from "@/components/ui/RouteHeader";
 
 interface BasicInfoLayoutProps {
@@ -22,15 +16,9 @@ interface BasicInfoLayoutProps {
 }
 
 export const BasicInfoLayout = ({ children, onSave }: BasicInfoLayoutProps) => {
-  const headerRef = useRef<HTMLDivElement>(null);
-  const { height = 0 } = useResizeObserver({
-    ref: headerRef as RefObject<HTMLDivElement>,
-  });
-
   return (
-    <div style={{ "--route-header-height": `${height}px` } as CSSProperties}>
+    <div>
       <RouteHeader
-        ref={headerRef}
         title="Basic Information"
         description="Set your study's title, description, and how it appears to participants."
         accessoryLeft={<RouteHeaderBackLink />}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -37,3 +37,9 @@ SPDX-License-Identifier: MIT
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
 }
+
+html {
+  --header-height: --spacing(14);
+  --route-header-height: --spacing(24);
+  scroll-padding-top: calc(var(--header-height) + var(--route-header-height));
+}


### PR DESCRIPTION
# Add a scroll padding

## :recycle: Current situation & Problem
Add scroll padding to the page to make sure input elements are always visible.

## :gear: Release Notes
* Added global CSS variables `--header-height` and `--route-header-height` to `index.css` and updated `scroll-padding-top` to use these variables.
* Updated the necessary components to set / use the new CSS variables.

## :white_check_mark: Testing
Manually tested.

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).