### PR TITLE
Closes #71: Add components to data model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,4 @@ eslint_report.json
 /playwright/.cache/
 
 # Server mock database
-/src/server/database/db.json
+/.dev-data/

--- a/docs/tutorials/development-server.md
+++ b/docs/tutorials/development-server.md
@@ -41,7 +41,7 @@ If you get a 404 or the page does not load, confirm `npm run dev` is still runni
 All development data lives in a JSON file. We can inspect it at any time.
 
 ```bash
-head -n 40 src/server/database/db.json
+head -n 40 .dev-data/db.json
 ```
 
 ## 4. Sign in from the API reference
@@ -64,7 +64,7 @@ What to notice: subsequent requests are now authorized because the dev server re
 
 Call `GET /api/studies`. If you signed in as an admin user, you will see all studies. If you signed in as a non-admin, you will see only studies for your teams.
 
-Variation: sign out with `POST /api/auth/sign-out`, then sign in as a different user from `db.json` and repeat the request to observe filtered results.
+Variation: sign out with `POST /api/auth/sign-out`, then sign in as a different user from `.dev-data/db.json` and repeat the request to observe filtered results.
 
 ## 7. Optional command line checks
 
@@ -87,10 +87,10 @@ curl -s -X POST http://localhost:3001/api/auth/sign-out | jq
 To fully reset data back to fixtures:
 
 ```bash
-rm -f src/server/database/db.json
+rm -rf .dev-data
 ```
 
-Issue a new request once you have removed the file. The server will recreate `db.json` with the default data.
+Issue a new request once you have removed the file. The server will recreate `.dev-data/db.json` with the default data.
 
 ## What we built
 

--- a/e2e/configuration.spec.ts
+++ b/e2e/configuration.spec.ts
@@ -7,12 +7,16 @@
 //
 
 import { expect, test } from "@/lib/playwrightFixtures";
+import { componentFixtures } from "@/server/database/entities/component/fixtures";
 import { studyFixtures } from "@/server/database/entities/study/fixtures";
 import { teamFixtures } from "@/server/database/entities/team/fixtures";
 import { loadApiMocks } from "@/server/mocks";
 
 const [team] = teamFixtures;
 const [study] = studyFixtures.filter((study) => study.teamId === team.id);
+const [component] = componentFixtures.filter(
+  (component) => component.studyId === study.id,
+);
 
 test.describe("Study Configuration Tests", () => {
   test.beforeEach(async ({ page }) => {
@@ -38,5 +42,39 @@ test.describe("Study Configuration Tests", () => {
         `/${team.id}/${study.id}/configuration/basic-information`,
       ),
     );
+  });
+
+  test("renders the components list with summary and schedule", async ({
+    page,
+  }) => {
+    await expect(
+      page.getByRole("heading", { name: "Components" }),
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole("link", { name: "Questionnaire" }),
+    ).toBeVisible();
+  });
+
+  test("navigates to the component detail page from the list", async ({
+    page,
+  }) => {
+    await page.getByRole("link", { name: "Questionnaire" }).click();
+    await expect(page).toHaveURL((url) =>
+      url.pathname.endsWith(
+        `/${team.id}/${study.id}/configuration/components/${component.id}`,
+      ),
+    );
+  });
+
+  test("opens the new component dialog", async ({ page }) => {
+    await page.getByRole("button", { name: "Add component" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Choose a component type" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("radio", { name: "Information" }),
+    ).toBeChecked();
   });
 });

--- a/src/components/interfaces/Header/HeaderSelectorSkeleton.tsx
+++ b/src/components/interfaces/Header/HeaderSelectorSkeleton.tsx
@@ -28,7 +28,7 @@ export const HeaderSelectorSkeleton = ({ hasIcon }: { hasIcon: boolean }) => {
         </div>
       )}
       <div className="grid h-4 w-20 flex-1">
-        <Skeleton className="bg-fill-secondary size-full rounded-sm" />
+        <Skeleton className="bg-fill-tertiary size-full rounded-sm" />
       </div>
       <ChevronsUpDown className="ml-auto" />
     </div>

--- a/src/components/interfaces/LogicGroupInput/ClauseValueInput.tsx
+++ b/src/components/interfaces/LogicGroupInput/ClauseValueInput.tsx
@@ -45,7 +45,7 @@ export const ClauseValueInput = ({
         <MultiSelectTrigger className="w-full sm:flex-1">
           <MultiSelectValue
             placeholder={placeholder}
-            className="[&_[data-selected-item=true]]:bg-fill-secondary"
+            className="*:bg-fill-tertiary"
           />
         </MultiSelectTrigger>
         <MultiSelectContent>

--- a/src/components/interfaces/Sidebar/MainNav.tsx
+++ b/src/components/interfaces/Sidebar/MainNav.tsx
@@ -33,6 +33,7 @@ interface NavBarItem {
   id?: string;
   title: string;
   linkOptions?: ValidateLinkOptions;
+  fuzzy?: boolean;
   icon?: LucideIcon;
   subMenu?: NavBarItem[];
 }
@@ -68,6 +69,8 @@ const navBarItems: NavBarItem[] = [
       {
         id: "components",
         title: "Components",
+        linkOptions: { to: "/$team/$study/configuration/components" },
+        fuzzy: true,
       },
     ],
   },
@@ -99,7 +102,7 @@ const MainNavButton = ({
       <Comp
         asChild
         tooltip={item.title}
-        isActive={!!matchRoute({ to: item.linkOptions.to })}
+        isActive={!!matchRoute({ to: item.linkOptions.to, fuzzy: item.fuzzy })}
       >
         <Link from="/" {...item.linkOptions}>
           {item.icon && <item.icon />}

--- a/src/components/ui/EditButton.tsx
+++ b/src/components/ui/EditButton.tsx
@@ -23,7 +23,7 @@ export const EditButton = ({
 }: EditButtonProps) => {
   return (
     <Button size={size} variant={variant} {...props}>
-      <Edit className="size-3.5" />
+      <Edit className="size-3.5 opacity-80" />
       Edit
     </Button>
   );
@@ -41,7 +41,7 @@ const BasicEditButtonLink = ({
 }: BasicEditButtonLinkProps) => {
   return (
     <a className={cn(buttonVariance({ variant, size }), className)} {...props}>
-      <Edit className="size-3.5" />
+      <Edit className="size-3.5 opacity-80" />
       Edit
     </a>
   );

--- a/src/components/ui/ImageUpload.tsx
+++ b/src/components/ui/ImageUpload.tsx
@@ -1,0 +1,223 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { Button, cn, Spinner } from "@stanfordspezi/spezi-web-design-system";
+import { ImageUp, X } from "lucide-react";
+import {
+  useState,
+  type RefCallback,
+  type ChangeEvent,
+  type ComponentProps,
+  type DragEvent,
+  type KeyboardEvent,
+  useRef,
+} from "react";
+import { FeaturedIconContainer } from "./FeaturedIconContainer";
+
+interface ImageUploadProps
+  extends Omit<ComponentProps<"input">, "value" | "onChange" | "type" | "ref"> {
+  ref: RefCallback<HTMLInputElement>;
+  value: string | null;
+  onChange: (value: string | null) => void;
+  maxSizeInMB?: number;
+  setError?: (error?: string) => void;
+}
+
+export const ImageUpload = ({
+  ref,
+  value,
+  className,
+  accept = "image/jpeg,image/png",
+  maxSizeInMB = 10,
+  disabled = false,
+  onChange,
+  setError,
+  ...props
+}: ImageUploadProps) => {
+  const [preview, setPreview] = useState(value);
+  const [isUploading, setIsUploading] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleFileSelect = (file: File) => {
+    setError?.(undefined);
+    // Validate file size
+    if (file.size > maxSizeInMB * 1024 * 1024) {
+      setError?.(`File size must be less than ${maxSizeInMB}MB`);
+      return;
+    }
+
+    // Validate file type - only allow JPEG, PNG
+    const allowedTypes = ["image/jpeg", "image/png"];
+    if (!allowedTypes.includes(file.type.toLowerCase())) {
+      setError?.("Only JPEG and PNG files are allowed");
+      return;
+    }
+
+    setIsUploading(true);
+
+    try {
+      // Create preview URL
+      const previewUrl = URL.createObjectURL(file);
+      setPreview(previewUrl);
+
+      // Convert file to base64 for temporary storage
+      const reader = new FileReader();
+      reader.onload = () => {
+        const base64String = reader.result as string;
+        onChange(base64String);
+        setIsUploading(false);
+      };
+      reader.onerror = () => {
+        setError?.("Failed to read file");
+        setIsUploading(false);
+      };
+      reader.readAsDataURL(file);
+    } catch {
+      setError?.("Failed to process file");
+      setIsUploading(false);
+    }
+  };
+
+  const handleDrop = (event: DragEvent) => {
+    event.preventDefault();
+    if (disabled || isUploading) return;
+
+    const files = Array.from(event.dataTransfer.files);
+    if (files.length > 0) {
+      handleFileSelect(files[0]);
+    }
+  };
+
+  const handleFileInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files;
+    if (files && files.length > 0) {
+      handleFileSelect(files[0]);
+    }
+  };
+
+  const handleRemove = () => {
+    if (preview?.startsWith("blob:")) {
+      URL.revokeObjectURL(preview);
+    }
+    setPreview(null);
+    onChange(null);
+    setError?.(undefined);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  const handleClick = () => {
+    if (!disabled && !isUploading) {
+      fileInputRef.current?.click();
+    }
+  };
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      handleClick();
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        "bg-fill-secondary border-border-secondary group group relative h-52 cursor-pointer rounded-lg border border-dashed transition",
+        "hover:border-border focus-ring",
+        disabled && "cursor-not-allowed opacity-50",
+        className,
+      )}
+      onDrop={handleDrop}
+      onDragOver={(event) => event.preventDefault()}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      tabIndex={disabled || isUploading ? -1 : 0}
+      role="button"
+      aria-label={preview ? "Change image" : "Upload image"}
+      aria-disabled={disabled || isUploading}
+    >
+      <input
+        ref={(element) => {
+          fileInputRef.current = element;
+          ref(element);
+        }}
+        type="file"
+        accept={accept}
+        onChange={handleFileInputChange}
+        className="hidden"
+        disabled={disabled || isUploading}
+        {...props}
+      />
+
+      {preview ?
+        <div className="flex-center relative size-full">
+          <img
+            src={preview}
+            alt="Preview"
+            className="h-48 w-full object-contain"
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size={null}
+            className="absolute top-2 right-2 size-8 rounded-md p-2"
+            onClick={(event) => {
+              // Prevent triggering the file input click
+              event.stopPropagation();
+              handleRemove();
+            }}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.stopPropagation();
+                event.preventDefault();
+                handleRemove();
+              }
+            }}
+            disabled={disabled || isUploading}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      : <div className="flex size-full flex-col items-center justify-center px-4 py-8">
+          {isUploading ?
+            <div className="flex-center flex-col gap-2 text-center">
+              <Spinner />
+              <p className="text-text-secondary text-sm">Uploading...</p>
+            </div>
+          : <div className="flex-center flex-col gap-2 text-center">
+              <FeaturedIconContainer
+                className={cn(
+                  "[--container-radius:var(--radius-md)]",
+                  "border-border-tertiary size-7 shadow-xs",
+                )}
+              >
+                <ImageUp
+                  className={cn(
+                    "size-full rounded p-[3px] opacity-80 transition",
+                    "group-hover:opacity-100",
+                  )}
+                />
+              </FeaturedIconContainer>
+              <div>
+                <p
+                  className={cn("text-sm transition", "group-hover:text-text")}
+                >
+                  Choose an image or drag & drop it here
+                </p>
+                <p className="text-text-tertiary text-xs">
+                  JPG, JPEG, PNG up to {maxSizeInMB}MB
+                </p>
+              </div>
+            </div>
+          }
+        </div>
+      }
+    </div>
+  );
+};

--- a/src/components/ui/PhoneMockup.tsx
+++ b/src/components/ui/PhoneMockup.tsx
@@ -16,15 +16,15 @@ const PhoneTopBar = () => {
       className="absolute top-(--phone-top-bar-padding-top) left-0 flex h-(--phone-top-bar-content-height) w-full items-center justify-between"
     >
       <div className="flex h-full flex-1 items-center justify-start pl-[8%]">
-        <div className="bg-fill-secondary h-1/3 w-1/2 rounded-full" />
+        <div className="bg-fill-tertiary h-1/3 w-1/2 rounded-full" />
       </div>
       <div className="flex-center h-full flex-1">
-        <div className="bg-fill-secondary h-3/5 w-full rounded-full" />
+        <div className="bg-fill-tertiary h-3/5 w-full rounded-full" />
       </div>
       <div className="flex h-full flex-1 items-center justify-end gap-[8%] pr-[8%]">
-        <div className="bg-fill-secondary aspect-square h-1/3 rounded-full" />
-        <div className="bg-fill-secondary aspect-square h-1/3 rounded-full" />
-        <div className="bg-fill-secondary aspect-square h-1/3 rounded-full" />
+        <div className="bg-fill-tertiary aspect-square h-1/3 rounded-full" />
+        <div className="bg-fill-tertiary aspect-square h-1/3 rounded-full" />
+        <div className="bg-fill-tertiary aspect-square h-1/3 rounded-full" />
       </div>
     </div>
   );

--- a/src/components/ui/RouteHeader.tsx
+++ b/src/components/ui/RouteHeader.tsx
@@ -53,12 +53,16 @@ export const RouteHeader = ({
         isScrolled && "shadow-lg shadow-black/2",
       )}
     >
-      <div className="flex max-w-7xl items-center justify-between p-6">
+      <div className="flex max-w-7xl items-center justify-between gap-2 p-6">
         <div className="flex gap-6">
           {accessoryLeft}
           <div className="space-y-1">
-            <h1 className="text-text leading-none font-medium">{title}</h1>
-            <p className="text-text-tertiary text-sm">{description}</p>
+            <h1 className="text-text line-clamp-1 leading-none font-medium">
+              {title}
+            </h1>
+            <p className="text-text-tertiary line-clamp-2 text-sm leading-tight">
+              {description}
+            </p>
           </div>
         </div>
         {accessoryRight}

--- a/src/components/ui/SaveButton.tsx
+++ b/src/components/ui/SaveButton.tsx
@@ -42,7 +42,7 @@ export const SaveButton = ({
         localIsSuccess &&
           "border-fill-success text-text-success-on-fill w-28 shadow-[inset_0_0_16px_--alpha(var(--color-fill-success)_/_50%)]",
         localIsError &&
-          "border-fill-tertiary !bg-fill-tertiary text-text-tertiary-on-fill w-28",
+          "border-fill-critical !bg-fill-critical text-text-critical-on-fill w-28",
         className,
       )}
       {...props}

--- a/src/lib/queries/component.ts
+++ b/src/lib/queries/component.ts
@@ -1,0 +1,234 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { toast } from "@stanfordspezi/spezi-web-design-system";
+import {
+  queryOptions,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { componentsApi } from "@/server/api/components";
+import type { ExtractZod, PathValue } from "@/utils/types";
+import { uploadImage } from "@/utils/uploadImage";
+import { apiRequest } from "../apiRequest";
+
+export const componentsQueryKeys = {
+  all: ["component"],
+  list: (params: ComponentListQueryOptionsParams) => [
+    "component",
+    "list",
+    params,
+  ],
+  retrieve: (params: ComponentRetrieveQueryOptionsParams) => [
+    "component",
+    "retrieve",
+    params,
+  ],
+} as const;
+
+interface ComponentListQueryOptionsParams {
+  studyId: string;
+}
+
+/**
+ * Query options for fetching all components for a study.
+ */
+export const componentListQueryOptions = (
+  params: ComponentListQueryOptionsParams,
+) => {
+  return queryOptions({
+    queryKey: componentsQueryKeys.list(params),
+    queryFn: () => {
+      return apiRequest({
+        route: componentsApi.routes.listForStudy,
+        params: { studyId: params.studyId },
+      });
+    },
+  });
+};
+
+interface ComponentRetrieveQueryOptionsParams {
+  componentId: string;
+}
+
+/**
+ * Query options for fetching a specific component by id.
+ */
+export const componentRetrieveQueryOptions = (
+  params: ComponentRetrieveQueryOptionsParams,
+) => {
+  return queryOptions({
+    queryKey: componentsQueryKeys.retrieve(params),
+    queryFn: () => {
+      return apiRequest({
+        route: componentsApi.routes.retrieve,
+        params: { id: params.componentId },
+      });
+    },
+  });
+};
+
+type CreateComponentBody = ExtractZod<
+  PathValue<
+    typeof componentsApi.routes.createForStudy,
+    ["request", "body", "content", "application/json", "schema"]
+  >
+>;
+
+type UseCreateComponentMutationFnParams = CreateComponentBody & {
+  studyId: string;
+};
+
+/**
+ * Processes form data to handle image uploads before creating/updating a component.
+ * Converts base64 image data to an uploaded image URL.
+ */
+export const uploadComponentImage = async <
+  T extends CreateComponentBody | UpdateComponentBody,
+>(
+  data: T,
+): Promise<T> => {
+  if (data.type !== "information") {
+    // Only information components can have images
+    return data;
+  }
+  if (!data.image?.startsWith("data:")) {
+    // No image or already a URL
+    return data;
+  }
+
+  try {
+    const uploadResult = await uploadImage({
+      base64DataUrl: data.image,
+    });
+
+    return { ...data, image: uploadResult.url };
+  } catch (error) {
+    console.error("Failed to upload image:", error);
+    toast.error("Image upload failed", {
+      description:
+        "The image could not be uploaded. The component will be created without an image.",
+      duration: 5000,
+    });
+    // Continue without image rather than failing the entire operation
+    return { ...data, image: null };
+  }
+};
+
+/**
+ * Mutation for creating a new component for a study.
+ */
+export const useCreateComponentMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      studyId,
+      ...data
+    }: UseCreateComponentMutationFnParams) => {
+      const body = await uploadComponentImage(data);
+      return apiRequest<typeof componentsApi.routes.createForStudy, 201>({
+        route: componentsApi.routes.createForStudy,
+        params: { studyId },
+        body,
+      });
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: componentsQueryKeys.all,
+      });
+    },
+    onError: (error) => {
+      toast.error("Error creating component", {
+        description: error.message,
+        duration: 5000,
+      });
+    },
+  });
+};
+
+type UpdateComponentBody = ExtractZod<
+  PathValue<
+    typeof componentsApi.routes.update,
+    ["request", "body", "content", "application/json", "schema"]
+  >
+>;
+
+type UseUpdateComponentMutationFnParams = UpdateComponentBody & {
+  componentId: string;
+};
+
+/**
+ * Mutation for updating a component.
+ */
+export const useUpdateComponentMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      componentId,
+      ...data
+    }: UseUpdateComponentMutationFnParams) => {
+      const body = await uploadComponentImage(data);
+      return apiRequest({
+        route: componentsApi.routes.update,
+        params: { id: componentId },
+        body,
+      });
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: componentsQueryKeys.all,
+      });
+    },
+    onError: (error) => {
+      toast.error("Error updating component", {
+        description: error.message,
+        duration: 5000,
+      });
+    },
+  });
+};
+
+interface UseDeleteComponentMutationFnParams {
+  componentId: string;
+  /** If provided, will target-invalidate the list for this study */
+  studyId?: string;
+}
+
+/**
+ * Mutation for deleting a component.
+ */
+export const useDeleteComponentMutation = ({
+  onSuccess,
+}: {
+  // We need this callback to allow for an async navigation after deletion
+  // but before the query invalidation happens. The mutater's onSuccess
+  // cannot be async because react-query does not await it.
+  onSuccess?: () => Promise<void>;
+} = {}) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ componentId }: UseDeleteComponentMutationFnParams) => {
+      return apiRequest<typeof componentsApi.routes.remove, 204>({
+        route: componentsApi.routes.remove,
+        params: { id: componentId },
+      });
+    },
+    onSuccess: async () => {
+      await onSuccess?.();
+      await queryClient.invalidateQueries({
+        queryKey: componentsQueryKeys.all,
+      });
+    },
+    onError: (error) => {
+      toast.error("Error deleting component", {
+        description: error.message,
+        duration: 5000,
+      });
+    },
+  });
+};

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -34,6 +34,9 @@ import { Route as dashboardTeamStudyIndexRouteImport } from './routes/~(dashboar
 import { Route as dashboardTeamStudyConfigurationEnrollmentRouteImport } from './routes/~(dashboard)/~$team/~$study/~configuration/~enrollment'
 import { Route as dashboardTeamStudyConfigurationBasicInformationRouteImport } from './routes/~(dashboard)/~$team/~$study/~configuration/~basic-information'
 import { Route as dashboardTeamStudyConfigurationIndexRouteImport } from './routes/~(dashboard)/~$team/~$study/~configuration/~index'
+import { Route as dashboardTeamStudyConfigurationComponentsNewRouteImport } from './routes/~(dashboard)/~$team/~$study/~configuration/~components/~new'
+import { Route as dashboardTeamStudyConfigurationComponentsComponentRouteImport } from './routes/~(dashboard)/~$team/~$study/~configuration/~components/~$component'
+import { Route as dashboardTeamStudyConfigurationComponentsIndexRouteImport } from './routes/~(dashboard)/~$team/~$study/~configuration/~components/~index'
 
 const dashboardLayoutRoute = dashboardLayoutRouteImport.update({
   id: '/(dashboard)',
@@ -119,6 +122,24 @@ const dashboardTeamStudyConfigurationIndexRoute =
     path: '/configuration/',
     getParentRoute: () => dashboardTeamStudyLayoutRoute,
   } as any)
+const dashboardTeamStudyConfigurationComponentsNewRoute =
+  dashboardTeamStudyConfigurationComponentsNewRouteImport.update({
+    id: '/configuration/components/new',
+    path: '/configuration/components/new',
+    getParentRoute: () => dashboardTeamStudyLayoutRoute,
+  } as any)
+const dashboardTeamStudyConfigurationComponentsComponentRoute =
+  dashboardTeamStudyConfigurationComponentsComponentRouteImport.update({
+    id: '/configuration/components/$component',
+    path: '/configuration/components/$component',
+    getParentRoute: () => dashboardTeamStudyLayoutRoute,
+  } as any)
+const dashboardTeamStudyConfigurationComponentsIndexRoute =
+  dashboardTeamStudyConfigurationComponentsIndexRouteImport.update({
+    id: '/configuration/components/',
+    path: '/configuration/components/',
+    getParentRoute: () => dashboardTeamStudyLayoutRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof dashboardIndexRoute
@@ -135,6 +156,9 @@ export interface FileRoutesByFullPath {
   '/$team/$study/configuration': typeof dashboardTeamStudyConfigurationIndexRoute
   '/$team/$study/configuration/basic-information': typeof dashboardTeamStudyConfigurationBasicInformationRoute
   '/$team/$study/configuration/enrollment': typeof dashboardTeamStudyConfigurationEnrollmentRoute
+  '/$team/$study/configuration/components': typeof dashboardTeamStudyConfigurationComponentsIndexRoute
+  '/$team/$study/configuration/components/$component': typeof dashboardTeamStudyConfigurationComponentsComponentRoute
+  '/$team/$study/configuration/components/new': typeof dashboardTeamStudyConfigurationComponentsNewRoute
 }
 export interface FileRoutesByTo {
   '/': typeof dashboardIndexRoute
@@ -149,6 +173,9 @@ export interface FileRoutesByTo {
   '/$team/$study/configuration': typeof dashboardTeamStudyConfigurationIndexRoute
   '/$team/$study/configuration/basic-information': typeof dashboardTeamStudyConfigurationBasicInformationRoute
   '/$team/$study/configuration/enrollment': typeof dashboardTeamStudyConfigurationEnrollmentRoute
+  '/$team/$study/configuration/components': typeof dashboardTeamStudyConfigurationComponentsIndexRoute
+  '/$team/$study/configuration/components/$component': typeof dashboardTeamStudyConfigurationComponentsComponentRoute
+  '/$team/$study/configuration/components/new': typeof dashboardTeamStudyConfigurationComponentsNewRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -167,6 +194,9 @@ export interface FileRoutesById {
   '/(dashboard)/$team/$study/configuration/': typeof dashboardTeamStudyConfigurationIndexRoute
   '/(dashboard)/$team/$study/configuration/basic-information': typeof dashboardTeamStudyConfigurationBasicInformationRoute
   '/(dashboard)/$team/$study/configuration/enrollment': typeof dashboardTeamStudyConfigurationEnrollmentRoute
+  '/(dashboard)/$team/$study/configuration/components/': typeof dashboardTeamStudyConfigurationComponentsIndexRoute
+  '/(dashboard)/$team/$study/configuration/components/$component': typeof dashboardTeamStudyConfigurationComponentsComponentRoute
+  '/(dashboard)/$team/$study/configuration/components/new': typeof dashboardTeamStudyConfigurationComponentsNewRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -185,6 +215,9 @@ export interface FileRouteTypes {
     | '/$team/$study/configuration'
     | '/$team/$study/configuration/basic-information'
     | '/$team/$study/configuration/enrollment'
+    | '/$team/$study/configuration/components'
+    | '/$team/$study/configuration/components/$component'
+    | '/$team/$study/configuration/components/new'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -199,6 +232,9 @@ export interface FileRouteTypes {
     | '/$team/$study/configuration'
     | '/$team/$study/configuration/basic-information'
     | '/$team/$study/configuration/enrollment'
+    | '/$team/$study/configuration/components'
+    | '/$team/$study/configuration/components/$component'
+    | '/$team/$study/configuration/components/new'
   id:
     | '__root__'
     | '/(dashboard)'
@@ -216,6 +252,9 @@ export interface FileRouteTypes {
     | '/(dashboard)/$team/$study/configuration/'
     | '/(dashboard)/$team/$study/configuration/basic-information'
     | '/(dashboard)/$team/$study/configuration/enrollment'
+    | '/(dashboard)/$team/$study/configuration/components/'
+    | '/(dashboard)/$team/$study/configuration/components/$component'
+    | '/(dashboard)/$team/$study/configuration/components/new'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -330,6 +369,27 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof dashboardTeamStudyConfigurationIndexRouteImport
       parentRoute: typeof dashboardTeamStudyLayoutRoute
     }
+    '/(dashboard)/$team/$study/configuration/components/new': {
+      id: '/(dashboard)/$team/$study/configuration/components/new'
+      path: '/configuration/components/new'
+      fullPath: '/$team/$study/configuration/components/new'
+      preLoaderRoute: typeof dashboardTeamStudyConfigurationComponentsNewRouteImport
+      parentRoute: typeof dashboardTeamStudyLayoutRoute
+    }
+    '/(dashboard)/$team/$study/configuration/components/$component': {
+      id: '/(dashboard)/$team/$study/configuration/components/$component'
+      path: '/configuration/components/$component'
+      fullPath: '/$team/$study/configuration/components/$component'
+      preLoaderRoute: typeof dashboardTeamStudyConfigurationComponentsComponentRouteImport
+      parentRoute: typeof dashboardTeamStudyLayoutRoute
+    }
+    '/(dashboard)/$team/$study/configuration/components/': {
+      id: '/(dashboard)/$team/$study/configuration/components/'
+      path: '/configuration/components'
+      fullPath: '/$team/$study/configuration/components'
+      preLoaderRoute: typeof dashboardTeamStudyConfigurationComponentsIndexRouteImport
+      parentRoute: typeof dashboardTeamStudyLayoutRoute
+    }
   }
 }
 
@@ -359,6 +419,9 @@ interface dashboardTeamStudyLayoutRouteChildren {
   dashboardTeamStudyConfigurationIndexRoute: typeof dashboardTeamStudyConfigurationIndexRoute
   dashboardTeamStudyConfigurationBasicInformationRoute: typeof dashboardTeamStudyConfigurationBasicInformationRoute
   dashboardTeamStudyConfigurationEnrollmentRoute: typeof dashboardTeamStudyConfigurationEnrollmentRoute
+  dashboardTeamStudyConfigurationComponentsIndexRoute: typeof dashboardTeamStudyConfigurationComponentsIndexRoute
+  dashboardTeamStudyConfigurationComponentsComponentRoute: typeof dashboardTeamStudyConfigurationComponentsComponentRoute
+  dashboardTeamStudyConfigurationComponentsNewRoute: typeof dashboardTeamStudyConfigurationComponentsNewRoute
 }
 
 const dashboardTeamStudyLayoutRouteChildren: dashboardTeamStudyLayoutRouteChildren =
@@ -372,6 +435,12 @@ const dashboardTeamStudyLayoutRouteChildren: dashboardTeamStudyLayoutRouteChildr
       dashboardTeamStudyConfigurationBasicInformationRoute,
     dashboardTeamStudyConfigurationEnrollmentRoute:
       dashboardTeamStudyConfigurationEnrollmentRoute,
+    dashboardTeamStudyConfigurationComponentsIndexRoute:
+      dashboardTeamStudyConfigurationComponentsIndexRoute,
+    dashboardTeamStudyConfigurationComponentsComponentRoute:
+      dashboardTeamStudyConfigurationComponentsComponentRoute,
+    dashboardTeamStudyConfigurationComponentsNewRoute:
+      dashboardTeamStudyConfigurationComponentsNewRoute,
   }
 
 const dashboardTeamStudyLayoutRouteWithChildren =

--- a/src/routes/~(dashboard)/~$team/~$study/~configuration/components/BasicInfoCard.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~configuration/components/BasicInfoCard.tsx
@@ -32,6 +32,7 @@ export const BasicInfoCard = ({ study, isLoading }: BasicInfoCardProps) => {
           from="/"
           to="/$team/$study/configuration/basic-information"
           params={params}
+          className="h-8 text-sm"
         />
       }
       isLoading={isLoading}

--- a/src/routes/~(dashboard)/~$team/~$study/~configuration/components/ComponentsCard/ComponentsCard.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~configuration/components/ComponentsCard/ComponentsCard.tsx
@@ -1,0 +1,85 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { Button } from "@stanfordspezi/spezi-web-design-system";
+import { Plus } from "lucide-react";
+import { Card, CardHeader } from "@/components/ui/Card";
+import type { Component } from "@/server/database/entities/component/schema";
+import { cn } from "@/utils/cn";
+import { ComponentsCardEmpty } from "./ComponentsCardEmpty";
+import { ComponentsCardRow } from "./ComponentsCardRow";
+import { ComponentsCardSkeleton } from "./ComponentsCardSkeleton";
+import { NewComponentDialog } from "./NewComponentDialog";
+
+const ComponentsCardHeader = () => {
+  return (
+    <CardHeader
+      title="Components"
+      description="The building blocks that define what participants see and do in your study."
+    >
+      <NewComponentDialog>
+        <Button size="sm" variant="outline" className="!h-8 text-sm">
+          <Plus className="size-3.5 opacity-80" />
+          Add component
+        </Button>
+      </NewComponentDialog>
+    </CardHeader>
+  );
+};
+
+const ComponentsCardContent = ({ components }: { components: Component[] }) => {
+  return (
+    <ul
+      className={cn(
+        "[--cols:200px_1fr_1fr_50px] [--row-h:--spacing(12)]",
+        "flex flex-col pb-(--card-padding)",
+      )}
+    >
+      <li
+        className={cn(
+          "bg-fill-secondary text-text-tertiary border-border-tertiary h-(--row-h) border-b px-(--card-padding) text-sm",
+          "grid grid-cols-(--cols) items-center gap-4",
+        )}
+      >
+        <p>Component</p>
+        <p>Summary</p>
+        <p>Schedule</p>
+      </li>
+      {components.map((component) => (
+        <ComponentsCardRow key={component.id} component={component} />
+      ))}
+    </ul>
+  );
+};
+
+interface ComponentsCardProps {
+  components?: Component[];
+  isLoading?: boolean;
+  showHeader?: boolean;
+}
+
+export const ComponentsCard = ({
+  components,
+  isLoading,
+  showHeader = true,
+}: ComponentsCardProps) => {
+  if (isLoading || !components) {
+    return <ComponentsCardSkeleton />;
+  }
+
+  if (components.length === 0) {
+    return <ComponentsCardEmpty />;
+  }
+
+  return (
+    <Card className="overflow-hidden">
+      {showHeader && <ComponentsCardHeader />}
+      <ComponentsCardContent components={components} />
+    </Card>
+  );
+};

--- a/src/routes/~(dashboard)/~$team/~$study/~configuration/components/ComponentsCard/ComponentsCardEmpty.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~configuration/components/ComponentsCard/ComponentsCardEmpty.tsx
@@ -1,0 +1,48 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { Button } from "@stanfordspezi/spezi-web-design-system";
+import { Component } from "lucide-react";
+import { Card } from "@/components/ui/Card";
+import { FeaturedIconContainer } from "@/components/ui/FeaturedIconContainer";
+import { cn } from "@/utils/cn";
+import { NewComponentDialog } from "./NewComponentDialog";
+
+export const ComponentsCardEmpty = () => {
+  return (
+    <Card>
+      <div className="bg-dots size-full">
+        <div
+          className={cn(
+            "from-layer size-full bg-radial from-50%",
+            "flex-center flex-col gap-4 p-12 text-center",
+          )}
+        >
+          <FeaturedIconContainer className="size-9 [--container-radius:var(--radius-lg)]">
+            <div className="bg-bg flex-center size-full inset-shadow-sm">
+              <Component className="size-4 opacity-80" />
+            </div>
+          </FeaturedIconContainer>
+          <div className="flex-center flex-col gap-0.5 text-sm">
+            <h1 className="max-w-48 font-medium text-balance">
+              No components yet
+            </h1>
+            <p className="text-text-tertiary">
+              Add your first component to begin building your study.
+            </p>
+          </div>
+          <NewComponentDialog>
+            <Button size="sm" className="!h-8 text-sm">
+              Create component
+            </Button>
+          </NewComponentDialog>
+        </div>
+      </div>
+    </Card>
+  );
+};

--- a/src/routes/~(dashboard)/~$team/~$study/~configuration/components/ComponentsCard/ComponentsCardRow.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~configuration/components/ComponentsCard/ComponentsCardRow.tsx
@@ -1,0 +1,120 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Tooltip,
+} from "@stanfordspezi/spezi-web-design-system";
+import { Link, useParams } from "@tanstack/react-router";
+import { Ellipsis } from "lucide-react";
+import { FeaturedIconContainer } from "@/components/ui/FeaturedIconContainer";
+import { useDeleteComponentMutation } from "@/lib/queries/component";
+import type { Component } from "@/server/database/entities/component/schema";
+import { cn } from "@/utils/cn";
+import { formatComponent } from "../../lib/formatComponent";
+
+interface ComponentsCardRowProps {
+  component: Component;
+}
+
+export const ComponentsCardRow = ({ component }: ComponentsCardRowProps) => {
+  const params = useParams({ strict: false });
+  const deleteComponent = useDeleteComponentMutation();
+
+  const { label, summary, schedule } = formatComponent(component);
+
+  if (!params.team || !params.study) {
+    console.warn("Missing team or study parameter");
+    return null;
+  }
+
+  return (
+    <li
+      className={cn(
+        "h-(--row-h) px-(--card-padding) text-sm",
+        "grid grid-cols-(--cols) items-center gap-4",
+        "border-border-tertiary border-b",
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <div>
+          <FeaturedIconContainer
+            className={cn(
+              "[--container-radius:var(--radius-md)]",
+              "border-border-tertiary size-6 shadow-xs",
+            )}
+          >
+            <label.icon
+              className={cn("size-full rounded p-[3px]", label.className)}
+            />
+          </FeaturedIconContainer>
+        </div>
+        <Link
+          to="/$team/$study/configuration/components/$component"
+          params={{
+            team: params.team,
+            study: params.study,
+            component: component.id,
+          }}
+          className="focus-ring hover:text-text decoration-text-tertiary min-w-0 truncate rounded-sm underline-offset-2 hover:underline"
+        >
+          {label.text}
+        </Link>
+      </div>
+      <div className="min-w-0">
+        <Tooltip
+          tooltip={summary}
+          className="whitespace-break-spaces"
+          variant="inverted"
+        >
+          <div className="max-w-fit truncate">{summary}</div>
+        </Tooltip>
+      </div>
+      <div className="min-w-0 truncate">{schedule}</div>
+      <div className="flex-center h-full">
+        <DropdownMenu modal={false}>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size={null}
+              className="size-8 rounded-sm p-2"
+            >
+              <Ellipsis className="opacity-80" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent side="left" align="start">
+            <DropdownMenuItem asChild>
+              <Link
+                to="/$team/$study/configuration/components/$component"
+                params={{
+                  team: params.team,
+                  study: params.study,
+                  component: component.id,
+                }}
+              >
+                Edit
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={deleteComponent.isPending}
+              onClick={() =>
+                deleteComponent.mutate({ componentId: component.id })
+              }
+            >
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </li>
+  );
+};

--- a/src/routes/~(dashboard)/~$team/~$study/~configuration/components/ComponentsCard/ComponentsCardSkeleton.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~configuration/components/ComponentsCard/ComponentsCardSkeleton.tsx
@@ -1,0 +1,54 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import {
+  Button,
+  Skeleton,
+  times,
+} from "@stanfordspezi/spezi-web-design-system";
+import { Plus } from "lucide-react";
+import { Card, CardHeader } from "@/components/ui/Card";
+import { cn } from "@/utils/cn";
+
+export const ComponentsCardSkeleton = () => {
+  return (
+    <Card>
+      <CardHeader
+        title="Components"
+        description="The building blocks that define what participants see and do in your study."
+      >
+        <Button size="sm" variant="outline" className="text-text h-8 text-sm">
+          <Plus className="size-3.5 opacity-80" />
+          Add component
+        </Button>
+      </CardHeader>
+      <ul
+        className={cn(
+          "[--cols:200px_1fr_1fr_50px] [--row-h:--spacing(10)]",
+          "flex flex-col gap-2 pb-(--card-padding)",
+        )}
+      >
+        <li
+          className={cn(
+            "bg-fill-secondary text-text-tertiary border-border-tertiary h-(--row-h) border-b px-(--card-padding) text-sm",
+            "grid grid-cols-(--cols) items-center gap-4",
+          )}
+        >
+          <p>Component</p>
+          <p>Summary</p>
+          <p>Schedule</p>
+        </li>
+        {times(3, (i) => (
+          <div key={i} className="px-(--card-padding)">
+            <Skeleton className="h-(--row-h) w-full" />
+          </div>
+        ))}
+      </ul>
+    </Card>
+  );
+};

--- a/src/routes/~(dashboard)/~$team/~$study/~configuration/components/ComponentsCard/NewComponentDialog.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~configuration/components/ComponentsCard/NewComponentDialog.tsx
@@ -1,0 +1,142 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  Field,
+  RadioGroup,
+  useForm,
+} from "@stanfordspezi/spezi-web-design-system";
+import { Link, useNavigate, useParams } from "@tanstack/react-router";
+import { Component } from "lucide-react";
+import { type ReactNode } from "react";
+import { z } from "zod";
+import { FeaturedIconContainer } from "@/components/ui/FeaturedIconContainer";
+
+const formSchema = z.object({
+  componentType: z.enum(["information", "questionnaire", "health-data"]),
+});
+
+interface RadioGroupOptionProps {
+  title: string;
+  description: string;
+}
+
+const RadioGroupOption = ({ title, description }: RadioGroupOptionProps) => (
+  <div className="flex flex-col gap-1">
+    <p className="font-medium">{title}</p>
+    <p className="text-text-tertiary text-sm">{description}</p>
+  </div>
+);
+
+interface NewComponentDialogProps {
+  children: ReactNode;
+}
+
+export const NewComponentDialog = ({ children }: NewComponentDialogProps) => {
+  const navigate = useNavigate();
+  const { team, study } = useParams({ strict: false });
+
+  const form = useForm({
+    formSchema,
+    defaultValues: { componentType: "information" },
+  });
+  const { componentType } = form.watch();
+
+  const handleSubmit = form.handleSubmit(async ({ componentType }) => {
+    if (!team || !study) return;
+    await navigate({
+      to: "/$team/$study/configuration/components/new",
+      params: { team, study },
+      search: { componentType },
+    });
+  });
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent size="2xl">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader className="items-center sm:items-start">
+            <FeaturedIconContainer className="border-border-tertiary mb-4 size-8 rounded-lg shadow-xs">
+              <div className="grid size-full place-items-center">
+                <Component className="text-text-tertiary size-4" />
+              </div>
+            </FeaturedIconContainer>
+            <DialogTitle>Choose a component type</DialogTitle>
+            <DialogDescription>
+              Select the type of component you want to add to your study. Each
+              type has different configuration options and purposes.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="pt-8">
+            <Field
+              control={form.control}
+              name="componentType"
+              render={({ field }) => (
+                <RadioGroup
+                  className="gap-y-6 [&_button]:-mt-px [&>label]:items-start"
+                  options={[
+                    {
+                      value: "information",
+                      label: (
+                        <RadioGroupOption
+                          title="Information"
+                          description="Display text and images to provide instructions, explanations, or context to participants."
+                        />
+                      ),
+                    },
+                    {
+                      value: "questionnaire",
+                      label: (
+                        <RadioGroupOption
+                          title="Questionnaire"
+                          description="Collect participant responses through structured questionnaires. Built on the HL7® FHIR® standard for interoperability."
+                        />
+                      ),
+                    },
+                    {
+                      value: "health-data",
+                      label: (
+                        <RadioGroupOption
+                          title="Health Data"
+                          description="Gather biomarker data from participants' connected devices. Define which health metrics to track and set collection frequency."
+                        />
+                      ),
+                    },
+                  ]}
+                  {...field}
+                />
+              )}
+            />
+          </div>
+          <DialogFooter>
+            {study && team && (
+              <Button variant="default" size="sm" asChild>
+                <Link
+                  to="/$team/$study/configuration/components/new"
+                  params={{ study, team }}
+                  search={{ componentType }}
+                >
+                  Create component
+                </Link>
+              </Button>
+            )}
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/routes/~(dashboard)/~$team/~$study/~configuration/components/EnrollmentCard.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~configuration/components/EnrollmentCard.tsx
@@ -37,6 +37,7 @@ export const EnrollmentCard = ({ study, isLoading }: EnrollmentCardProps) => {
           from="/"
           to="/$team/$study/configuration/enrollment"
           params={params}
+          className="h-8 text-sm"
         />
       }
       isLoading={isLoading}

--- a/src/routes/~(dashboard)/~$team/~$study/~configuration/lib/formatComponent.ts
+++ b/src/routes/~(dashboard)/~$team/~$study/~configuration/lib/formatComponent.ts
@@ -1,0 +1,102 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import {
+  Activity,
+  CheckSquare,
+  FileText,
+  HelpCircle,
+  type LucideIcon,
+} from "lucide-react";
+import type { Component } from "@/server/database/entities/component/schema";
+import { cn } from "@/utils/cn";
+import { truncate } from "@/utils/truncate";
+import { formatSchedule } from "./formatSchedule";
+import { healthDataTypes } from "./healthDataTypes";
+
+interface ComponentLabel {
+  text: string;
+  icon: LucideIcon;
+  className: string;
+}
+
+const getComponentLabel = (component: Component): ComponentLabel => {
+  switch (component.type) {
+    case "information":
+      return {
+        icon: FileText,
+        text: component.title,
+        // Using cn() here to get intellisense for the Tailwind class names
+        // Enable in .vscode/settings.json: "tailwindCSS.classFunctions": ["cva", "cn"]
+        className: cn("bg-blue-500 text-blue-50"),
+      };
+    case "questionnaire":
+      return {
+        icon: CheckSquare,
+        text: "Questionnaire",
+        className: cn("bg-orange-500 text-orange-50"),
+      };
+    case "health-data":
+      return {
+        icon: Activity,
+        text: "Health Data",
+        className: cn("bg-green-500 text-green-50"),
+      };
+    default:
+      return {
+        icon: HelpCircle,
+        text: "Component",
+        className: cn("bg-fill"),
+      };
+  }
+};
+
+const getComponentSummary = (component: Component): string => {
+  switch (component.type) {
+    case "information":
+      return truncate(component.content, 200);
+    case "questionnaire": {
+      const jsonString = JSON.stringify(
+        JSON.parse(component.fhirQuestionnaireJson),
+        null,
+        2,
+      );
+      return truncate(jsonString, 200);
+    }
+    case "health-data": {
+      const healthDataTypeItems = Object.values(healthDataTypes).flat();
+      const types = component.sampleTypes.slice(0, 10).map((type) => {
+        const item = healthDataTypeItems.find((item) => item.value === type);
+        return item ? item.label : type;
+      });
+      return component.sampleTypes.length > 10 ?
+          types.join(",\n") + "…"
+        : types.join(",\n");
+    }
+    default:
+      return "No summary available";
+  }
+};
+
+const getComponentSchedule = (component: Component): string => {
+  if (!component.schedule) {
+    return "Not scheduled";
+  }
+  return formatSchedule(component.schedule);
+};
+
+/**
+ * Formats a component by extracting values for label, summary, and schedule.
+ */
+export const formatComponent = (component: Component) => {
+  const label = getComponentLabel(component);
+  const summary = getComponentSummary(component);
+  const schedule = getComponentSchedule(component);
+
+  return { label, summary, schedule };
+};

--- a/src/routes/~(dashboard)/~$team/~$study/~configuration/lib/formatSchedule.ts
+++ b/src/routes/~(dashboard)/~$team/~$study/~configuration/lib/formatSchedule.ts
@@ -1,0 +1,87 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import type { z } from "zod";
+import type { scheduleSchema } from "@/server/database/entities/component/schema";
+
+/**
+ * Helper function to get ordinal suffix for numbers
+ */
+const getOrdinalSuffix = (num: number): string => {
+  const lastDigit = num % 10;
+  const lastTwoDigits = num % 100;
+
+  if (lastTwoDigits >= 11 && lastTwoDigits <= 13) {
+    return "th";
+  }
+
+  switch (lastDigit) {
+    case 1:
+      return "st";
+    case 2:
+      return "nd";
+    case 3:
+      return "rd";
+    default:
+      return "th";
+  }
+};
+
+/**
+ * Converts a schedule object into a human-readable string
+ *
+ * @example
+ * formatSchedule({
+ *   startOffset: 10,
+ *   repeatType: "daily",
+ *   repeatInterval: 5,
+ *   displayHour: 9,
+ *   displayMinute: 10
+ * })
+ * // Returns: "Activates every 5th day at 9:10 AM. Starts 10 days after start."
+ */
+export const formatSchedule = ({
+  startOffset,
+  repeatType,
+  repeatInterval,
+  displayHour,
+  displayMinute,
+}: NonNullable<z.infer<typeof scheduleSchema>>) => {
+  const timeDate = new Date();
+  timeDate.setHours(displayHour, displayMinute);
+  const timeString = timeDate.toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  });
+
+  let frequencyString: string;
+  if (repeatType === "daily") {
+    if (repeatInterval === 1) {
+      frequencyString = "Daily";
+    } else {
+      const ordinal = getOrdinalSuffix(repeatInterval);
+      frequencyString = `Every ${repeatInterval}${ordinal} day`;
+    }
+  } else {
+    // weekly
+    if (repeatInterval === 1) {
+      frequencyString = "Weekly";
+    } else {
+      const ordinal = getOrdinalSuffix(repeatInterval);
+      frequencyString = `Every ${repeatInterval}${ordinal} week`;
+    }
+  }
+
+  const startString =
+    startOffset === 0 ? "Starts immediately" : (
+      `Starts after ${startOffset} ${startOffset === 1 ? "day" : "days"}`
+    );
+
+  return `${frequencyString} at ${timeString}. ${startString}.`;
+};

--- a/src/routes/~(dashboard)/~$team/~$study/~configuration/lib/healthDataTypes.ts
+++ b/src/routes/~(dashboard)/~$team/~$study/~configuration/lib/healthDataTypes.ts
@@ -1,0 +1,218 @@
+export const healthDataTypes = {
+  Correlation: [
+    {
+      label: "Blood Pressure",
+      value: "HKCorrelationType;HKCorrelationTypeIdentifierBloodPressure",
+    },
+  ],
+  Category: [
+    {
+      label: "Mindful Session",
+      value: "HKCategoryType;HKCategoryTypeIdentifierMindfulSession",
+    },
+    {
+      label: "Sleep Analysis",
+      value: "HKCategoryType;HKCategoryTypeIdentifierSleepAnalysis",
+    },
+    {
+      label: "Apple Stand Hour",
+      value: "HKCategoryType;HKCategoryTypeIdentifierAppleStandHour",
+    },
+    {
+      label: "High Heart Rate Event",
+      value: "HKCategoryType;HKCategoryTypeIdentifierHighHeartRateEvent",
+    },
+    {
+      label: "Low Heart Rate Event",
+      value: "HKCategoryType;HKCategoryTypeIdentifierLowHeartRateEvent",
+    },
+    {
+      label: "Apple Walking Steadiness Event",
+      value:
+        "HKCategoryType;HKCategoryTypeIdentifierAppleWalkingSteadinessEvent",
+    },
+    {
+      label: "Irregular Heart Rhythm Event",
+      value: "HKCategoryType;HKCategoryTypeIdentifierIrregularHeartRhythmEvent",
+    },
+  ],
+  Quantity: [
+    {
+      label: "Apple Walking Steadiness",
+      value: "HKQuantityType;HKQuantityTypeIdentifierAppleWalkingSteadiness",
+    },
+    {
+      label: "Heart Rate Variability SDNN",
+      value: "HKQuantityType;HKQuantityTypeIdentifierHeartRateVariabilitySDNN",
+    },
+    {
+      label: "Dietary Cholesterol",
+      value: "HKQuantityType;HKQuantityTypeIdentifierDietaryCholesterol",
+    },
+    {
+      label: "Walking Speed",
+      value: "HKQuantityType;HKQuantityTypeIdentifierWalkingSpeed",
+    },
+    {
+      label: "Body Mass Index",
+      value: "HKQuantityType;HKQuantityTypeIdentifierBodyMassIndex",
+    },
+    {
+      label: "Blood Alcohol Content",
+      value: "HKQuantityType;HKQuantityTypeIdentifierBloodAlcoholContent",
+    },
+    {
+      label: "Distance Wheelchair",
+      value: "HKQuantityType;HKQuantityTypeIdentifierDistanceWheelchair",
+    },
+    {
+      label: "Resting Heart Rate",
+      value: "HKQuantityType;HKQuantityTypeIdentifierRestingHeartRate",
+    },
+    {
+      label: "VO2 Max",
+      value: "HKQuantityType;HKQuantityTypeIdentifierVO2Max",
+    },
+    {
+      label: "Active Energy Burned",
+      value: "HKQuantityType;HKQuantityTypeIdentifierActiveEnergyBurned",
+    },
+    {
+      label: "Inhaler Usage",
+      value: "HKQuantityType;HKQuantityTypeIdentifierInhalerUsage",
+    },
+    {
+      label: "Body Mass",
+      value: "HKQuantityType;HKQuantityTypeIdentifierBodyMass",
+    },
+    {
+      label: "Stair Ascent Speed",
+      value: "HKQuantityType;HKQuantityTypeIdentifierStairAscentSpeed",
+    },
+    {
+      label: "Distance Walking Running",
+      value: "HKQuantityType;HKQuantityTypeIdentifierDistanceWalkingRunning",
+    },
+    {
+      label: "Stair Descent Speed",
+      value: "HKQuantityType;HKQuantityTypeIdentifierStairDescentSpeed",
+    },
+    {
+      label: "Six Minute Walk Test Distance",
+      value: "HKQuantityType;HKQuantityTypeIdentifierSixMinuteWalkTestDistance",
+    },
+    {
+      label: "Blood Glucose",
+      value: "HKQuantityType;HKQuantityTypeIdentifierBloodGlucose",
+    },
+    {
+      label: "Respiratory Rate",
+      value: "HKQuantityType;HKQuantityTypeIdentifierRespiratoryRate",
+    },
+    {
+      label: "Waist Circumference",
+      value: "HKQuantityType;HKQuantityTypeIdentifierWaistCircumference",
+    },
+    {
+      label: "Apple Stand Time",
+      value: "HKQuantityType;HKQuantityTypeIdentifierAppleStandTime",
+    },
+    {
+      label: "Basal Body Temperature",
+      value: "HKQuantityType;HKQuantityTypeIdentifierBasalBodyTemperature",
+    },
+    {
+      label: "Walking Asymmetry Percentage",
+      value:
+        "HKQuantityType;HKQuantityTypeIdentifierWalkingAsymmetryPercentage",
+    },
+    {
+      label: "Flights Climbed",
+      value: "HKQuantityType;HKQuantityTypeIdentifierFlightsClimbed",
+    },
+    {
+      label: "Basal Energy Burned",
+      value: "HKQuantityType;HKQuantityTypeIdentifierBasalEnergyBurned",
+    },
+    {
+      label: "Body Temperature",
+      value: "HKQuantityType;HKQuantityTypeIdentifierBodyTemperature",
+    },
+    {
+      label: "Heart Rate",
+      value: "HKQuantityType;HKQuantityTypeIdentifierHeartRate",
+    },
+    {
+      label: "Distance Swimming",
+      value: "HKQuantityType;HKQuantityTypeIdentifierDistanceSwimming",
+    },
+    {
+      label: "Body Fat Percentage",
+      value: "HKQuantityType;HKQuantityTypeIdentifierBodyFatPercentage",
+    },
+    {
+      label: "Heart Rate Recovery One Minute",
+      value:
+        "HKQuantityType;HKQuantityTypeIdentifierHeartRateRecoveryOneMinute",
+    },
+    {
+      label: "Atrial Fibrillation Burden",
+      value: "HKQuantityType;HKQuantityTypeIdentifierAtrialFibrillationBurden",
+    },
+    {
+      label: "Height",
+      value: "HKQuantityType;HKQuantityTypeIdentifierHeight",
+    },
+    {
+      label: "Apple Exercise Time",
+      value: "HKQuantityType;HKQuantityTypeIdentifierAppleExerciseTime",
+    },
+    {
+      label: "Lean Body Mass",
+      value: "HKQuantityType;HKQuantityTypeIdentifierLeanBodyMass",
+    },
+    {
+      label: "Step Count",
+      value: "HKQuantityType;HKQuantityTypeIdentifierStepCount",
+    },
+    {
+      label: "Walking Step Length",
+      value: "HKQuantityType;HKQuantityTypeIdentifierWalkingStepLength",
+    },
+    {
+      label: "Oxygen Saturation",
+      value: "HKQuantityType;HKQuantityTypeIdentifierOxygenSaturation",
+    },
+    {
+      label: "Walking Double Support Percentage",
+      value:
+        "HKQuantityType;HKQuantityTypeIdentifierWalkingDoubleSupportPercentage",
+    },
+    {
+      label: "Distance Cycling",
+      value: "HKQuantityType;HKQuantityTypeIdentifierDistanceCycling",
+    },
+    {
+      label: "Dietary Vitamin D",
+      value: "HKQuantityType;HKQuantityTypeIdentifierDietaryVitaminD",
+    },
+    {
+      label: "Apple Move Time",
+      value: "HKQuantityType;HKQuantityTypeIdentifierAppleMoveTime",
+    },
+    {
+      label: "Walking Heart Rate Average",
+      value: "HKQuantityType;HKQuantityTypeIdentifierWalkingHeartRateAverage",
+    },
+  ],
+  Other: [
+    {
+      label: "Electrocardiogram",
+      value: "HKElectrocardiogramType;HKDataTypeIdentifierElectrocardiogram",
+    },
+    {
+      label: "Workout",
+      value: "HKWorkoutType;HKWorkoutTypeIdentifier",
+    },
+  ],
+};

--- a/src/routes/~(dashboard)/~$team/~$study/~configuration/~basic-information.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~configuration/~basic-information.tsx
@@ -50,6 +50,8 @@ const BasicInformationRouteComponent = () => {
     <BasicInfoLayout
       saveButton={
         <SaveButton
+          size="sm"
+          className="text-sm"
           onClick={handleSave}
           isPending={updateStudy.isPending}
           isSuccess={updateStudy.isSuccess}

--- a/src/routes/~(dashboard)/~$team/~$study/~configuration/~components/~$component.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~configuration/~components/~$component.tsx
@@ -1,0 +1,19 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { createFileRoute } from "@tanstack/react-router";
+
+const EditComponentRoute = () => {
+  return <div>Edit Component Route</div>;
+};
+
+export const Route = createFileRoute(
+  "/(dashboard)/$team/$study/configuration/components/$component",
+)({
+  component: EditComponentRoute,
+});

--- a/src/routes/~(dashboard)/~$team/~$study/~configuration/~components/~index.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~configuration/~components/~index.tsx
@@ -1,0 +1,19 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { createFileRoute } from "@tanstack/react-router";
+
+const ComponentsRoute = () => {
+  return <p>Components Route</p>;
+};
+
+export const Route = createFileRoute(
+  "/(dashboard)/$team/$study/configuration/components/",
+)({
+  component: ComponentsRoute,
+});

--- a/src/routes/~(dashboard)/~$team/~$study/~configuration/~components/~new.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~configuration/~components/~new.tsx
@@ -1,0 +1,25 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+const NewComponentRoute = () => {
+  return <p>New Component Route</p>;
+};
+
+export const Route = createFileRoute(
+  "/(dashboard)/$team/$study/configuration/components/new",
+)({
+  component: NewComponentRoute,
+  validateSearch: z.object({
+    componentType: z
+      .enum(["information", "questionnaire", "health-data"])
+      .optional(),
+  }),
+});

--- a/src/routes/~(dashboard)/~$team/~$study/~configuration/~enrollment.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~configuration/~enrollment.tsx
@@ -41,6 +41,8 @@ const EnrollmentRouteComponent = () => {
     <EnrollmentLayout
       saveButton={
         <SaveButton
+          size="sm"
+          className="text-sm"
           onClick={handleSave}
           isPending={isPending}
           isSuccess={isSuccess}

--- a/src/routes/~(dashboard)/~$team/~$study/~configuration/~index.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~configuration/~index.tsx
@@ -9,15 +9,20 @@
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { RouteHeader } from "@/components/ui/RouteHeader";
+import { componentListQueryOptions } from "@/lib/queries/component";
 import { studyRetrieveQueryOptions } from "@/lib/queries/study";
 import { BasicInfoCard } from "./components/BasicInfoCard";
+import { ComponentsCard } from "./components/ComponentsCard/ComponentsCard";
 import { EnrollmentCard } from "./components/EnrollmentCard";
 import { StatusBadge } from "./components/StatusBadge";
 
 const StudyConfigurationRoute = () => {
   const params = Route.useParams();
-  const { data: study, isLoading } = useQuery(
+  const { data: study, isLoading: isStudyLoading } = useQuery(
     studyRetrieveQueryOptions({ studyId: params.study }),
+  );
+  const { data: components, isLoading: isComponentsLoading } = useQuery(
+    componentListQueryOptions({ studyId: params.study }),
   );
   return (
     <div>
@@ -26,9 +31,13 @@ const StudyConfigurationRoute = () => {
         description="Configure your study and everything related to it."
         accessoryRight={<StatusBadge isPublished={study?.isPublished} />}
       />
-      <div className="flex max-w-7xl flex-col gap-14 p-6">
-        <BasicInfoCard study={study} isLoading={isLoading} />
-        <EnrollmentCard study={study} isLoading={isLoading} />
+      <div className="flex max-w-7xl flex-col gap-14 p-6 pb-12">
+        <BasicInfoCard study={study} isLoading={isStudyLoading} />
+        <EnrollmentCard study={study} isLoading={isStudyLoading} />
+        <ComponentsCard
+          components={components}
+          isLoading={isComponentsLoading}
+        />
       </div>
     </div>
   );

--- a/src/server/api/components/handlers.ts
+++ b/src/server/api/components/handlers.ts
@@ -1,0 +1,184 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { getDevDatabase, setDevDatabase } from "@/server/database";
+import type { Component } from "@/server/database/entities/component/schema";
+import { respondWithError } from "@/server/error";
+import { type AppRouteHandler } from "@/server/utils";
+import type {
+  CreateForStudyRoute,
+  DeleteRoute,
+  ListForStudyRoute,
+  RetrieveRoute,
+  UpdateRoute,
+} from "./routes";
+
+export const listForStudy: AppRouteHandler<ListForStudyRoute> = (c) => {
+  const param = c.req.valid("param");
+  const user = c.get("user");
+
+  const db = getDevDatabase();
+
+  const study = db.studies.find((study) => study.id === param.studyId);
+  if (!study) {
+    return respondWithError(c, 404, {
+      message: `Study with id ${param.studyId} not found. Make sure it exists and ${user.id} has access to it.`,
+    });
+  }
+
+  if (user.role !== "admin" && !user.teamIds?.includes(study.teamId)) {
+    return respondWithError(c, 404, {
+      message: `Study with id ${param.studyId} not found. Make sure it exists and ${user.id} has access to it.`,
+    });
+  }
+
+  const items = db.components.filter(
+    (component) => component.studyId === param.studyId,
+  );
+  return c.json(items, 200);
+};
+
+export const createForStudy: AppRouteHandler<CreateForStudyRoute> = (c) => {
+  const param = c.req.valid("param");
+  const body = c.req.valid("json");
+  const user = c.get("user");
+
+  const db = getDevDatabase();
+  const study = db.studies.find((study) => study.id === param.studyId);
+  if (!study) {
+    return respondWithError(c, 404, {
+      message: `Study with id ${param.studyId} not found. Make sure it exists and ${user.id} has access to it.`,
+    });
+  }
+
+  if (user.role !== "admin" && !user.teamIds?.includes(study.teamId)) {
+    return respondWithError(c, 404, {
+      message: `Study with id ${param.studyId} not found. Make sure it exists and ${user.id} has access to it.`,
+    });
+  }
+
+  const newComponent: Component = {
+    id: `comp_${Date.now()}`,
+    studyId: param.studyId,
+    ...body,
+  };
+
+  const newComponents = [...db.components, newComponent];
+  setDevDatabase({ components: newComponents });
+
+  return c.json(newComponent, 201);
+};
+
+export const retrieve: AppRouteHandler<RetrieveRoute> = (c) => {
+  const param = c.req.valid("param");
+  const user = c.get("user");
+
+  const db = getDevDatabase();
+  const component = db.components.find(
+    (component) => component.id === param.id,
+  );
+  if (!component) {
+    return respondWithError(c, 404, {
+      message: `Component with id ${param.id} not found.`,
+    });
+  }
+
+  const study = db.studies.find((study) => study.id === component.studyId);
+  if (!study) {
+    return respondWithError(c, 404, {
+      message: `Study with id ${component.studyId} not found. Make sure it exists and ${user.id} has access to it.`,
+    });
+  }
+
+  if (user.role !== "admin" && !user.teamIds?.includes(study.teamId)) {
+    return respondWithError(c, 404, {
+      message: `Component with id ${param.id} not found.`,
+    });
+  }
+
+  return c.json(component, 200);
+};
+
+export const update: AppRouteHandler<UpdateRoute> = (c) => {
+  const param = c.req.valid("param");
+  const body = c.req.valid("json");
+  const user = c.get("user");
+
+  const db = getDevDatabase();
+  const component = db.components.find(
+    (component) => component.id === param.id,
+  );
+  if (!component) {
+    return respondWithError(c, 404, {
+      message: `Component with id ${param.id} not found.`,
+    });
+  }
+
+  const study = db.studies.find((study) => study.id === component.studyId);
+  if (!study) {
+    return respondWithError(c, 404, {
+      message: `Study with id ${component.studyId} not found. Make sure it exists and ${user.id} has access to it.`,
+    });
+  }
+
+  if (user.role !== "admin" && !user.teamIds?.includes(study.teamId)) {
+    return respondWithError(c, 404, {
+      message: `Component with id ${param.id} not found.`,
+    });
+  }
+
+  const updated = {
+    ...component,
+    ...body,
+    // Enforce immutable fields
+    id: component.id,
+    studyId: component.studyId,
+    type: component.type,
+  } as Component;
+  const newComponents = db.components.map((component) =>
+    component.id === param.id ? updated : component,
+  );
+  setDevDatabase({ components: newComponents });
+
+  return c.json(updated, 200);
+};
+
+export const remove: AppRouteHandler<DeleteRoute> = (c) => {
+  const param = c.req.valid("param");
+  const user = c.get("user");
+
+  const db = getDevDatabase();
+  const component = db.components.find(
+    (component) => component.id === param.id,
+  );
+  if (!component) {
+    return respondWithError(c, 404, {
+      message: `Component with id ${param.id} not found.`,
+    });
+  }
+
+  const study = db.studies.find((study) => study.id === component.studyId);
+  if (!study) {
+    return respondWithError(c, 404, {
+      message: `Study with id ${component.studyId} not found. Make sure it exists and ${user.id} has access to it.`,
+    });
+  }
+
+  if (user.role !== "admin" && !user.teamIds?.includes(study.teamId)) {
+    return respondWithError(c, 404, {
+      message: `Component with id ${param.id} not found.`,
+    });
+  }
+
+  const newComponents = db.components.filter(
+    (component) => component.id !== param.id,
+  );
+  setDevDatabase({ components: newComponents });
+
+  return c.body(null, 204);
+};

--- a/src/server/api/components/index.ts
+++ b/src/server/api/components/index.ts
@@ -1,0 +1,25 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { createHonoApp } from "@/server/utils";
+import * as handlers from "./handlers";
+import * as routes from "./routes";
+
+const router = createHonoApp();
+
+router
+  .openapi(routes.listForStudy, handlers.listForStudy)
+  .openapi(routes.createForStudy, handlers.createForStudy)
+  .openapi(routes.retrieve, handlers.retrieve)
+  .openapi(routes.update, handlers.update)
+  .openapi(routes.remove, handlers.remove);
+
+export const componentsApi = {
+  router,
+  routes,
+};

--- a/src/server/api/components/routes.ts
+++ b/src/server/api/components/routes.ts
@@ -1,0 +1,123 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { createRoute, z } from "@hono/zod-openapi";
+import { error404Schema } from "@/server/error";
+import { openApiTags } from "@/server/tags";
+import {
+  componentInsertBodySchema,
+  componentListParams,
+  componentRetrieveParams,
+  componentSelectSchema,
+  componentUpdateSchema,
+} from "./schema";
+
+export type ListForStudyRoute = typeof listForStudy;
+export const listForStudy = createRoute({
+  tags: [openApiTags.components.name],
+  path: "/studies/:studyId/components",
+  method: "get",
+  description: "List all components for a study",
+  request: { params: componentListParams },
+  responses: {
+    200: {
+      content: {
+        "application/json": { schema: z.array(componentSelectSchema) },
+      },
+      description: "The list of components for the study",
+    },
+    404: {
+      content: { "application/json": { schema: error404Schema } },
+      description: "Study not found or inaccessible",
+    },
+  },
+});
+
+export type CreateForStudyRoute = typeof createForStudy;
+export const createForStudy = createRoute({
+  tags: [openApiTags.components.name],
+  path: "/studies/:studyId/components",
+  method: "post",
+  description: "Create a new component for a study",
+  request: {
+    params: componentListParams,
+    body: {
+      content: { "application/json": { schema: componentInsertBodySchema } },
+    },
+  },
+  responses: {
+    201: {
+      content: { "application/json": { schema: componentSelectSchema } },
+      description: "The created component",
+    },
+    404: {
+      content: { "application/json": { schema: error404Schema } },
+      description: "Study not found or inaccessible",
+    },
+  },
+});
+
+export type RetrieveRoute = typeof retrieve;
+export const retrieve = createRoute({
+  tags: [openApiTags.components.name],
+  path: "/components/:id",
+  method: "get",
+  description: "Retrieve a specific component by its id",
+  request: { params: componentRetrieveParams },
+  responses: {
+    200: {
+      content: { "application/json": { schema: componentSelectSchema } },
+      description: "The component details",
+    },
+    404: {
+      content: { "application/json": { schema: error404Schema } },
+      description: "Component not found",
+    },
+  },
+});
+
+export type UpdateRoute = typeof update;
+export const update = createRoute({
+  tags: [openApiTags.components.name],
+  path: "/components/:id",
+  method: "patch",
+  description: "Update a specific component by its id",
+  request: {
+    params: componentRetrieveParams,
+    body: {
+      content: { "application/json": { schema: componentUpdateSchema } },
+      description: "The component fields to update",
+    },
+  },
+  responses: {
+    200: {
+      content: { "application/json": { schema: componentSelectSchema } },
+      description: "The updated component",
+    },
+    404: {
+      content: { "application/json": { schema: error404Schema } },
+      description: "Component not found",
+    },
+  },
+});
+
+export type DeleteRoute = typeof remove;
+export const remove = createRoute({
+  tags: [openApiTags.components.name],
+  path: "/components/:id",
+  method: "delete",
+  description: "Delete a specific component by its id",
+  request: { params: componentRetrieveParams },
+  responses: {
+    204: { description: "Component deleted" },
+    404: {
+      content: { "application/json": { schema: error404Schema } },
+      description: "Component not found",
+    },
+  },
+});

--- a/src/server/api/components/schema.ts
+++ b/src/server/api/components/schema.ts
@@ -1,0 +1,112 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { z } from "@hono/zod-openapi";
+
+const scheduleSchema = z
+  .object({
+    startOffset: z.number().openapi({ example: 0 }),
+    repeatType: z.enum(["daily", "weekly"]).openapi({ example: "daily" }),
+    repeatInterval: z.number().openapi({ example: 1 }),
+    displayHour: z.number().openapi({ example: 9 }),
+    displayMinute: z.number().openapi({ example: 0 }),
+  })
+  .nullable()
+  .openapi({
+    description: "Optional schedule for activating the component",
+  });
+
+const baseComponentSchema = z.object({
+  id: z.string().openapi({ example: "comp_123" }),
+  studyId: z.string().openapi({ example: "study_sleep_patterns" }),
+  schedule: scheduleSchema,
+});
+
+const informationComponentSchema = baseComponentSchema.extend({
+  type: z.literal("information"),
+  title: z.string().openapi({ example: "Welcome" }),
+  content: z.string().openapi({ example: "# Welcome to the study" }),
+  image: z.string().nullable().openapi({ example: null }),
+});
+
+const healthDataComponentSchema = baseComponentSchema.extend({
+  type: z.literal("health-data"),
+  sampleTypes: z
+    .string()
+    .array()
+    .openapi({ example: ["heart_rate"] }),
+});
+
+const questionnaireComponentSchema = baseComponentSchema.extend({
+  type: z.literal("questionnaire"),
+  fhirQuestionnaireJson: z
+    .string()
+    .openapi({ example: '{"resourceType":"Questionnaire","title":"Survey"}' }),
+});
+
+export const componentSelectSchema = z.discriminatedUnion("type", [
+  informationComponentSchema,
+  healthDataComponentSchema,
+  questionnaireComponentSchema,
+]);
+
+// Create body: same shapes without id and studyId (studyId is provided via path)
+const baseCreateSchema = z.object({ schedule: scheduleSchema });
+const informationCreateSchema = baseCreateSchema.extend({
+  type: z.literal("information"),
+  title: z.string(),
+  content: z.string(),
+  image: z.string().nullable(),
+});
+const healthDataCreateSchema = baseCreateSchema.extend({
+  type: z.literal("health-data"),
+  sampleTypes: z.string().array(),
+});
+const questionnaireCreateSchema = baseCreateSchema.extend({
+  type: z.literal("questionnaire"),
+  fhirQuestionnaireJson: z.string(),
+});
+export const componentInsertBodySchema = z.discriminatedUnion("type", [
+  informationCreateSchema,
+  healthDataCreateSchema,
+  questionnaireCreateSchema,
+]);
+
+const baseUpdateSchema = z.object({ schedule: scheduleSchema.optional() });
+const informationUpdateSchema = baseUpdateSchema.extend({
+  type: z.literal("information"),
+  title: z.string().optional(),
+  content: z.string().optional(),
+  image: z.string().nullable().optional(),
+});
+
+const healthDataUpdateSchema = baseUpdateSchema.extend({
+  type: z.literal("health-data"),
+  sampleTypes: z.string().array().optional(),
+});
+
+const questionnaireUpdateSchema = baseUpdateSchema.extend({
+  type: z.literal("questionnaire"),
+  fhirQuestionnaireJson: z.string().optional(),
+});
+
+export const componentUpdateSchema = z
+  .discriminatedUnion("type", [
+    informationUpdateSchema,
+    healthDataUpdateSchema,
+    questionnaireUpdateSchema,
+  ])
+  .openapi({ description: "Partial update of a component" });
+
+export const componentRetrieveParams = z.object({
+  id: z.string().openapi({ example: "comp_123" }),
+});
+
+export const componentListParams = z.object({
+  studyId: z.string().openapi({ example: "study_sleep_patterns" }),
+});

--- a/src/server/api/studies/routes.ts
+++ b/src/server/api/studies/routes.ts
@@ -104,7 +104,7 @@ export type UpdateRoute = typeof update;
 export const update = createRoute({
   tags: [openApiTags.studies.name],
   path: "/studies/:id",
-  method: "put",
+  method: "patch",
   description: "Update a specific study by its id",
   request: {
     params: studyRetrieveParams,

--- a/src/server/api/uploads/handlers.ts
+++ b/src/server/api/uploads/handlers.ts
@@ -1,0 +1,106 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import fs from "node:fs";
+import path from "node:path";
+import { getDevAssetsPath } from "@/server/database";
+import { respondWithError } from "@/server/error";
+import { type AppRouteHandler } from "@/server/utils";
+import type { ServeImageRoute, UploadImageRoute } from "./routes";
+
+export const uploadImage: AppRouteHandler<UploadImageRoute> = async (c) => {
+  const formData = await c.req.formData();
+  const imageFile = formData.get("image");
+
+  if (!imageFile || !(imageFile instanceof File)) {
+    return respondWithError(c, 400, {
+      message: "No image file provided",
+    });
+  }
+
+  const allowedTypes = ["image/jpeg", "image/png"];
+  if (!allowedTypes.includes(imageFile.type.toLowerCase())) {
+    return respondWithError(c, 400, {
+      message: "Only JPG, JPEG, and PNG files are allowed",
+    });
+  }
+
+  // Validate file size (max 10MB)
+  const maxSize = 10 * 1024 * 1024;
+  if (imageFile.size > maxSize) {
+    return respondWithError(c, 400, {
+      message: "File size must be less than 10MB",
+    });
+  }
+
+  // Generate unique filename with proper extension
+  const timestamp = Date.now();
+  const extension = path.extname(imageFile.name).toLowerCase();
+
+  const baseUrl = c.req.url.replace(c.req.path, "");
+  const filename = `${timestamp}-${Math.random().toString(36).substring(2)}${extension}`;
+  const imageId = filename.replace(extension, "");
+
+  // Save file to assets folder
+  const assetsPath = getDevAssetsPath();
+  const filePath = path.join(assetsPath, filename);
+
+  const arrayBuffer = await imageFile.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+  fs.writeFileSync(filePath, buffer);
+
+  return c.json(
+    {
+      id: imageId,
+      url: `${baseUrl}/api/uploads/${imageId}`,
+      filename: imageFile.name,
+      size: imageFile.size,
+      mimeType: imageFile.type,
+    },
+    201,
+  );
+};
+
+export const serveImage: AppRouteHandler<ServeImageRoute> = (c) => {
+  const param = c.req.valid("param");
+
+  const assetsPath = getDevAssetsPath();
+  const files = fs.readdirSync(assetsPath);
+
+  const filename = files.find((file) => file.startsWith(param.imageId));
+
+  if (!filename) {
+    return respondWithError(c, 404, {
+      message: "Image not found",
+    });
+  }
+
+  const filePath = path.join(assetsPath, filename);
+
+  if (!fs.existsSync(filePath)) {
+    return respondWithError(c, 404, {
+      message: "Image not found",
+    });
+  }
+
+  const fileBuffer = fs.readFileSync(filePath);
+  const extension = path.extname(filename).toLowerCase();
+
+  // Set appropriate content type
+  let contentType = "application/octet-stream";
+  if (extension === ".jpg" || extension === ".jpeg") {
+    contentType = "image/jpeg";
+  } else if (extension === ".png") {
+    contentType = "image/png";
+  }
+
+  c.header("Content-Type", contentType);
+  c.header("Cache-Control", "public, max-age=31536000"); // Cache for 1 year
+
+  return c.body(fileBuffer);
+};

--- a/src/server/api/uploads/index.ts
+++ b/src/server/api/uploads/index.ts
@@ -1,0 +1,22 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { createHonoApp } from "@/server/utils";
+import * as handlers from "./handlers";
+import * as routes from "./routes";
+
+const router = createHonoApp();
+
+router
+  .openapi(routes.uploadImage, handlers.uploadImage)
+  .openapi(routes.serveImage, handlers.serveImage);
+
+export const uploadsApi = {
+  router,
+  routes,
+};

--- a/src/server/api/uploads/routes.ts
+++ b/src/server/api/uploads/routes.ts
@@ -1,0 +1,71 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { createRoute } from "@hono/zod-openapi";
+import { createErrorSchema, error404Schema } from "@/server/error";
+import { openApiTags } from "@/server/tags";
+import {
+  serveImageParamsSchema,
+  serveImageResponseSchema,
+  uploadImageInsertBodySchema,
+  uploadImageResponseSchema,
+} from "./schema";
+
+export type UploadImageRoute = typeof uploadImage;
+export const uploadImage = createRoute({
+  tags: [openApiTags.uploads.name],
+  path: "/upload/image",
+  method: "post",
+  description: "Upload an image",
+  request: {
+    body: {
+      content: {
+        "multipart/form-data": {
+          schema: uploadImageInsertBodySchema,
+        },
+      },
+    },
+  },
+  responses: {
+    201: {
+      content: { "application/json": { schema: uploadImageResponseSchema } },
+      description: "Image uploaded successfully",
+    },
+    400: {
+      content: {
+        "application/json": {
+          schema: createErrorSchema({
+            message: "Invalid file or file too large",
+          }),
+        },
+      },
+      description: "Invalid file or file too large",
+    },
+  },
+});
+
+export type ServeImageRoute = typeof serveImage;
+export const serveImage = createRoute({
+  tags: [openApiTags.uploads.name],
+  path: "/uploads/:imageId",
+  method: "get",
+  description: "Serve an uploaded image",
+  request: { params: serveImageParamsSchema },
+  responses: {
+    200: {
+      content: {
+        "image/*": { schema: serveImageResponseSchema },
+      },
+      description: "Image file",
+    },
+    404: {
+      content: { "application/json": { schema: error404Schema } },
+      description: "Image not found",
+    },
+  },
+});

--- a/src/server/api/uploads/schema.ts
+++ b/src/server/api/uploads/schema.ts
@@ -1,0 +1,36 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { z } from "@hono/zod-openapi";
+
+export const uploadImageInsertBodySchema = z.object({
+  image: z.instanceof(File).describe("Image file to upload").openapi({
+    type: "string",
+    format: "binary",
+  }),
+});
+
+export const uploadImageResponseSchema = z.object({
+  id: z.string().openapi({ example: "1687623456789-abcd1234" }),
+  url: z.string().openapi({ example: "/api/uploads/1687623456789-abcd1234" }),
+  filename: z.string().openapi({ example: "image.png" }),
+  size: z.number().openapi({ example: 1024 }),
+  mimeType: z.string().openapi({ example: "image/png" }),
+});
+
+export const serveImageParamsSchema = z.object({
+  imageId: z.string().min(1).openapi({ example: "1687623456789-abcd1234" }),
+});
+
+export const serveImageResponseSchema = z
+  .string()
+  .describe("Image file")
+  .openapi({
+    type: "string",
+    format: "binary",
+  });

--- a/src/server/database/entities/component/fixtures.ts
+++ b/src/server/database/entities/component/fixtures.ts
@@ -1,0 +1,51 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import type { Component } from "./schema";
+
+export const componentFixtures: Component[] = [
+  {
+    id: "comp_welcome",
+    studyId: "study_sleep_patterns",
+    type: "information",
+    title: "Welcome",
+    content: "# Welcome to the Sleep Patterns Study\nWe're glad you're here!",
+    image: null,
+    schedule: null,
+  },
+  {
+    id: "comp_daily_hr",
+    studyId: "study_sleep_patterns",
+    type: "health-data",
+    sampleTypes: ["HKCategoryType;HKCategoryTypeIdentifierAppleStandHour"],
+    schedule: {
+      startOffset: 0,
+      repeatType: "daily",
+      repeatInterval: 1,
+      displayHour: 8,
+      displayMinute: 0,
+    },
+  },
+  {
+    id: "comp_morning_survey",
+    studyId: "study_activity",
+    type: "questionnaire",
+    fhirQuestionnaireJson: JSON.stringify({
+      resourceType: "Questionnaire",
+      title: "Morning Check-in",
+      item: [{ linkId: "1", text: "How did you sleep?", type: "choice" }],
+    }),
+    schedule: {
+      startOffset: 0,
+      repeatType: "daily",
+      repeatInterval: 1,
+      displayHour: 9,
+      displayMinute: 0,
+    },
+  },
+];

--- a/src/server/database/entities/component/schema.ts
+++ b/src/server/database/entities/component/schema.ts
@@ -1,0 +1,50 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { z } from "zod";
+
+export const scheduleSchema = z
+  .object({
+    startOffset: z.number(),
+    repeatType: z.enum(["daily", "weekly"]),
+    repeatInterval: z.number(),
+    displayHour: z.number(),
+    displayMinute: z.number(),
+  })
+  .nullable();
+
+const baseComponentSchema = z.object({
+  id: z.string(),
+  studyId: z.string(),
+  schedule: scheduleSchema,
+});
+
+const informationComponentSchema = baseComponentSchema.extend({
+  type: z.literal("information"),
+  title: z.string(),
+  content: z.string(),
+  image: z.string().nullable(),
+});
+
+const healthDataComponentSchema = baseComponentSchema.extend({
+  type: z.literal("health-data"),
+  sampleTypes: z.string().array(),
+});
+
+const questionnaireComponentSchema = baseComponentSchema.extend({
+  type: z.literal("questionnaire"),
+  fhirQuestionnaireJson: z.string(),
+});
+
+export const componentSchema = z.discriminatedUnion("type", [
+  informationComponentSchema,
+  healthDataComponentSchema,
+  questionnaireComponentSchema,
+]);
+
+export type Component = z.infer<typeof componentSchema>;

--- a/src/server/database/index.ts
+++ b/src/server/database/index.ts
@@ -8,6 +8,8 @@
 
 import fs from "node:fs";
 import { z } from "zod";
+import { componentFixtures } from "./entities/component/fixtures";
+import { componentSchema } from "./entities/component/schema";
 import { studyFixtures } from "./entities/study/fixtures";
 import { studySchema } from "./entities/study/schema";
 import { teamFixtures } from "./entities/team/fixtures";
@@ -15,11 +17,14 @@ import { teamSchema } from "./entities/team/schema";
 import { userFixtures } from "./entities/user/fixtures";
 import { userSchema } from "./entities/user/schema";
 
-const devDatabasePath = "src/server/database/db.json";
+const devDataPath = ".dev-data";
+const devDatabasePath = `${devDataPath}/db.json`;
+const devAssetsPath = `${devDataPath}/assets`;
 
 const devDatabaseSchema = z.object({
   currentUser: userSchema.nullable(),
   studies: studySchema.array(),
+  components: componentSchema.array(),
   teams: teamSchema.array(),
   users: userSchema.array(),
 });
@@ -31,12 +36,14 @@ const devDatabaseFixtures: Record<string, DevDatabase> = {
   default: {
     currentUser: null,
     studies: studyFixtures,
+    components: componentFixtures,
     teams: teamFixtures,
     users: userFixtures,
   },
   empty: {
     currentUser: null,
     studies: [],
+    components: [],
     teams: [],
     users: userFixtures,
   },
@@ -44,6 +51,18 @@ const devDatabaseFixtures: Record<string, DevDatabase> = {
 
 // Current development database, change this to test different scenarios
 const initialDevDatabase: DevDatabase = devDatabaseFixtures.default;
+
+/**
+ * Ensures the development data folder structure exists.
+ */
+const ensureDevDataStructure = (): void => {
+  if (!fs.existsSync(devDataPath)) {
+    fs.mkdirSync(devDataPath, { recursive: true });
+  }
+  if (!fs.existsSync(devAssetsPath)) {
+    fs.mkdirSync(devAssetsPath, { recursive: true });
+  }
+};
 
 /**
  * Retrieves the development database from the file system.
@@ -54,6 +73,8 @@ const initialDevDatabase: DevDatabase = devDatabaseFixtures.default;
  * it with the default development database and returns it.
  */
 export const getDevDatabase = (): DevDatabase => {
+  ensureDevDataStructure();
+
   const hasDatabase = fs.existsSync(devDatabasePath);
   if (hasDatabase) {
     const data = fs.readFileSync(devDatabasePath, "utf-8");
@@ -91,4 +112,12 @@ export const setDevDatabase = (data: Partial<DevDatabase>): void => {
       cause: z.treeifyError(parsed.error).errors.join(", "),
     });
   }
+};
+
+/**
+ * Get the path to the development assets folder.
+ */
+export const getDevAssetsPath = (): string => {
+  ensureDevDataStructure();
+  return devAssetsPath;
 };

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -14,8 +14,10 @@ import { cors } from "hono/cors";
 import { HTTPException } from "hono/http-exception";
 import { dedent } from "@/utils/dedent";
 import { authApi } from "./api/auth";
+import { componentsApi } from "./api/components";
 import { studiesApi } from "./api/studies";
 import { teamsApi } from "./api/teams";
+import { uploadsApi } from "./api/uploads";
 import { usersApi } from "./api/users";
 import { respondWithError } from "./error";
 import { authMiddleware } from "./middleware";
@@ -29,7 +31,7 @@ app.use(
   cors({
     origin: ["http://localhost:3000"], // We only need to point to the local frontend origin
     allowHeaders: ["Content-Type", "Authorization"],
-    allowMethods: ["OPTIONS", "GET", "POST", "PUT", "DELETE"],
+    allowMethods: ["OPTIONS", "GET", "POST", "PUT", "PATCH", "DELETE"],
     exposeHeaders: ["Content-Length"],
     maxAge: 600,
     credentials: true,
@@ -43,7 +45,13 @@ app.route("/api", authApi.router);
 app.use("/api/*", authMiddleware);
 
 // These routes require authentication
-const routers = [studiesApi.router, teamsApi.router, usersApi.router] as const;
+const routers = [
+  studiesApi.router,
+  componentsApi.router,
+  teamsApi.router,
+  usersApi.router,
+  uploadsApi.router,
+];
 routers.forEach((router) => {
   app.route("/api", router);
 });

--- a/src/server/mocks/index.ts
+++ b/src/server/mocks/index.ts
@@ -8,6 +8,7 @@
 
 import type { Page } from "@playwright/test";
 import { mockAuthRoutes } from "./routes/auth";
+import { mockComponentsRoutes } from "./routes/components";
 import { mockStudiesRoutes } from "./routes/studies";
 import { mockTeamsRoutes } from "./routes/teams";
 import { mockUserRoutes } from "./routes/user";
@@ -29,12 +30,13 @@ export const loadApiMocks = (page: Page, options: LoadApiMocksOptions = {}) => {
     mockUserRoutes(page, { role }),
     mockTeamsRoutes(page),
     mockStudiesRoutes(page),
+    mockComponentsRoutes(page),
   ]);
 };
 
 interface ClearMockDataParams {
   page: Page;
-  entity: "teams" | "studies";
+  entity: "teams" | "studies" | "components";
 }
 
 /**

--- a/src/server/mocks/routes/components.ts
+++ b/src/server/mocks/routes/components.ts
@@ -1,0 +1,84 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import type { Page } from "@playwright/test";
+import { componentsApi } from "@/server/api/components";
+import { componentFixtures } from "@/server/database/entities/component/fixtures";
+import type { Component } from "@/server/database/entities/component/schema";
+import { mockApiRoute } from "@/utils/mockApiRoute";
+
+export const mockComponentsRoutes = async (page: Page) => {
+  const components: Component[] = structuredClone(componentFixtures);
+
+  await mockApiRoute(page, {
+    route: componentsApi.routes.listForStudy,
+    response: ({ params }) => {
+      const { studyId } = params;
+      const items = components.filter(
+        (component) => component.studyId === studyId,
+      );
+      return { status: 200, body: items };
+    },
+  });
+
+  await mockApiRoute(page, {
+    route: componentsApi.routes.createForStudy,
+    response: ({ params, body }) => {
+      const { studyId } = params;
+      const newComp: Component = {
+        id: "new-comp-id",
+        studyId,
+        ...body,
+      } as Component;
+      components.push(newComp);
+      return { status: 201, body: newComp };
+    },
+  });
+
+  await mockApiRoute(page, {
+    route: componentsApi.routes.retrieve,
+    response: ({ params }) => {
+      const { id } = params;
+      const item = components.find((component) => component.id === id);
+      if (!item) return { status: 404, body: { message: "Not found" } };
+      return { status: 200, body: item };
+    },
+  });
+
+  await mockApiRoute(page, {
+    route: componentsApi.routes.update,
+    response: ({ params, body }) => {
+      const { id } = params;
+      const index = components.findIndex((component) => component.id === id);
+      if (index === -1) return { status: 404, body: { message: "Not found" } };
+      const updated = { ...components[index], ...body } as Component;
+      components[index] = updated;
+      return { status: 200, body: updated };
+    },
+  });
+
+  await mockApiRoute(page, {
+    route: componentsApi.routes.remove,
+    response: ({ params }) => {
+      const { id } = params;
+      const index = components.findIndex((component) => component.id === id);
+      if (index === -1) return { status: 404, body: { message: "Not found" } };
+      components.splice(index, 1);
+      return { status: 204, body: undefined };
+    },
+  });
+
+  await page.route(`http://localhost:3001/api/components/_clear`, (route) => {
+    const url = new URL(route.request().url());
+    if (url.pathname.endsWith("/_clear")) {
+      components.length = 0;
+      return route.fulfill({ status: 200 });
+    }
+    return route.continue();
+  });
+};

--- a/src/server/tags.ts
+++ b/src/server/tags.ts
@@ -26,4 +26,14 @@ export const openApiTags = {
     name: "Users",
     description: "Retrieve user information.",
   },
+  components: {
+    name: "Components",
+    description:
+      "Manage study components such as informational screens, health data collection, and questionnaires.",
+  },
+  uploads: {
+    name: "Uploads",
+    description:
+      "Handle image uploads. For example, upload and retrieve images used in study components.",
+  },
 };

--- a/src/styles/color.css
+++ b/src/styles/color.css
@@ -77,8 +77,8 @@ SPDX-License-Identifier: MIT
 
   /* Fill */
   --color-fill: var(--color-zinc-10);
-  --color-fill-secondary: var(--color-zinc-200);
-  --color-fill-tertiary: var(--color-zinc-500);
+  --color-fill-secondary: var(--color-zinc-50);
+  --color-fill-tertiary: var(--color-zinc-200);
   --color-fill-brand: var(--color-brand-500);
   --color-fill-brand-hover: var(--color-brand-450);
   --color-fill-brand-active: var(--color-brand-400);

--- a/src/utils/truncate.ts
+++ b/src/utils/truncate.ts
@@ -1,0 +1,16 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+/**
+ * Truncates a string to a specified maximum length, appending an ellipsis ("…") if the string exceeds the length.
+ * If the string is shorter than or equal to the maximum length, it returns the original string.
+ */
+export const truncate = (text: string, maxLength: number) => {
+  if (text.length <= maxLength) return text;
+  return text.slice(0, maxLength) + "…";
+};

--- a/src/utils/uploadImage.ts
+++ b/src/utils/uploadImage.ts
@@ -1,0 +1,74 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { buildApiUrl, handleApiResponse } from "@/lib/apiRequest";
+import { uploadsApi } from "@/server/api/uploads";
+import type { ExtractZod, PathValue } from "@/utils/types";
+
+/**
+ * Extracts the file extension from a base64 data URL based on its MIME type.
+ *
+ * @example
+ * const extension = extractExtensionFromDataUrl("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...");
+ * console.log(extension); // Outputs: ".png"
+ */
+const extractExtensionFromDataUrl = (dataUrl: string) => {
+  const mimeType = dataUrl.split(";")[0].split(":")[1];
+
+  if (mimeType === "image/png") {
+    return ".png";
+  }
+  if (mimeType === "image/jpeg" || mimeType === "image/jpg") {
+    return ".jpg";
+  }
+
+  // Default to ".jpg" for unsupported or unknown MIME types, as JPEG is widely supported.
+  return ".jpg";
+};
+
+type UploadImageApiResponse = ExtractZod<
+  PathValue<
+    typeof uploadsApi.routes.uploadImage,
+    ["responses", 201, "content", "application/json", "schema"]
+  >
+>;
+
+interface UploadImageParams {
+  base64DataUrl: string;
+}
+
+/**
+ * Uploads an image to the server. Takes a base64 data URL and converts it to a File for upload.
+ */
+export const uploadImage = async ({ base64DataUrl }: UploadImageParams) => {
+  // Convert base64 data URL to File
+  const response = await fetch(base64DataUrl);
+  const blob = await response.blob();
+  const fileName = `upload${extractExtensionFromDataUrl(base64DataUrl)}`;
+  const file = new File([blob], fileName, { type: blob.type });
+
+  // Create FormData and append the file
+  const formData = new FormData();
+  formData.append("image", file);
+
+  const requestUrl = buildApiUrl({
+    apiPath: uploadsApi.routes.uploadImage.path,
+  });
+
+  const fetchOptions: RequestInit = {
+    method: "POST",
+    headers: {
+      // 'Content-Type' is set automatically by the browser for FormData
+    },
+    body: formData,
+    credentials: "include",
+  };
+
+  const apiResponse = await fetch(requestUrl, fetchOptions);
+  return handleApiResponse<UploadImageApiResponse>(apiResponse);
+};


### PR DESCRIPTION
# Add components to data model

<img width="1920" height="1080" alt="983shots_so" src="https://github.com/user-attachments/assets/0308291d-96e1-4544-83bb-50f89a306bde" />

## :recycle: Current situation & Problem
Components are not yet part of the study definition.

## :gear: Release Notes

### Database & Data Model
-  Introduced `componentSchema` with discriminated union for three component types: `information` (title, content, image, schedule), `questionnaire` (FHIR JSON, schedule), and `health-data` (sample types array, schedule).
-  Added `componentFixtures` with sample data for testing (e.g., welcome info page, daily heart rate tracking, morning survey).
-  Updated dev database structure: Moved from `src/server/database/db.json` to `.dev-data/db.json` for better separation; added `components` array to schema and fixtures; created `.dev-data/assets` for image storage.

### Backend APIs
-  New `/api/components` routes: `GET /studies/:studyId/components` (list), `POST /studies/:studyId/components` (create), `GET /components/:id` (retrieve), `PATCH /components/:id` (update), `DELETE /components/:id` (remove) with Zod validation and auth checks.
-  Added `/api/uploads` for image handling: `POST /upload/image` (multipart upload with size/type validation, max 10MB, JPEG/PNG only) and `GET /uploads/:imageId` (serve with caching).

### Frontend UI & Routing
-  New study configuration dashboard at `/configuration/components`: Lists components in a card with summary/schedule columns; supports add/edit/delete via modals and navigation.
-  Components card UI: `ComponentsCard` (with header, rows, skeleton, empty state); `NewComponentDialog` (radio group for type selection: information/questionnaire/health-data); row formatting with icons, truncation, and delete dropdown.
-  Routing updates: Added TanStack Router paths for `/configuration/components`, `/components/$component`, `/components/new`; integrated into study layout with navigation links.
-  New components: `ImageUpload` component (drag/drop, preview, validation).

## :white_check_mark: Testing
Updated `study-configuration.spec.ts` to test components list, navigation, new dialog (visibility, radio selection); added `mockComponentsRoutes` for API simulation.

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).