### PR TITLE
Closes #74: Add missing component flows

### DIFF
--- a/e2e/components.spec.ts
+++ b/e2e/components.spec.ts
@@ -88,6 +88,81 @@ test.describe("Study Component Tests", () => {
     await expect(page.getByRole("link", { name: updatedTitle })).toBeVisible();
   });
 
+  test("updates a health data component configuration", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { name: "Components", level: 1 }),
+    ).toBeVisible();
+
+    await page.getByRole("link", { name: "Health Data" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Health Data Component" }),
+    ).toBeVisible();
+
+    const historicalInput = page.getByRole("spinbutton", {
+      name: "Historical data collection",
+    });
+    await historicalInput.fill("14");
+
+    const sampleTypesTrigger = page
+      .getByRole("combobox")
+      .filter({ hasText: "Apple Stand Hour" })
+      .first();
+    await expect(sampleTypesTrigger).toContainText("Apple Stand Hour");
+
+    await sampleTypesTrigger.click();
+    await page
+      .getByRole("option")
+      .filter({ hasText: /^Heart Rate$/ })
+      .click();
+    await page
+      .getByRole("option")
+      .filter({ hasText: /^Sleep Analysis$/ })
+      .click();
+    await page.keyboard.press("Escape");
+
+    await expect(sampleTypesTrigger).toContainText("Heart Rate");
+    await expect(sampleTypesTrigger).toContainText("Sleep Analysis");
+
+    await page.getByRole("button", { name: /^save$/i }).click();
+    await expect(page.getByRole("button", { name: "Saved" })).toBeVisible();
+
+    await page.getByRole("link", { name: "Back" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Components", level: 1 }),
+    ).toBeVisible();
+  });
+
+  test("formats questionnaire JSON before saving", async ({ page }) => {
+    await page.getByRole("link", { name: "Morning Check-in" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Questionnaire Component" }),
+    ).toBeVisible();
+
+    const questionnaireTextarea = page.getByRole("textbox", {
+      name: "FHIR Questionnaire JSON",
+    });
+
+    const rawJson =
+      '{"resourceType":"Questionnaire","title":"Daily Mood","item":[]}';
+    const formattedJson = `{
+  "resourceType": "Questionnaire",
+  "title": "Daily Mood",
+  "item": []
+}`;
+
+    await questionnaireTextarea.fill(rawJson);
+    await page.getByRole("button", { name: "Format JSON" }).click();
+    await expect(questionnaireTextarea).toHaveValue(formattedJson);
+
+    await page.getByRole("button", { name: /^save$/i }).click();
+    await expect(page.getByRole("button", { name: "Saved" })).toBeVisible();
+
+    await page.getByRole("link", { name: "Back" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Components", level: 1 }),
+    ).toBeVisible();
+  });
+
   test("deletes an information component", async ({ page }) => {
     await page.getByRole("link", { name: "Welcome" }).click();
     await expect(

--- a/src/components/interfaces/DurationInput.tsx
+++ b/src/components/interfaces/DurationInput.tsx
@@ -1,0 +1,156 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import {
+  Input,
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  type Nil,
+} from "@stanfordspezi/spezi-web-design-system";
+import { useState, type ComponentProps, type ChangeEvent } from "react";
+
+interface DurationInputProps
+  extends Omit<ComponentProps<typeof Input>, "onChange"> {
+  onChange?: (days: number | null) => void;
+}
+
+const timeMultipliers = {
+  days: 1,
+  weeks: 7,
+} as const;
+
+type TimeUnit = keyof typeof timeMultipliers;
+
+/**
+ * Determines the most appropriate time unit for a given number of days.
+ * Prefers larger units if the days value is a clean multiple.
+ */
+const getOptimalTimeUnit = (days: number): TimeUnit => {
+  if (days % timeMultipliers.weeks === 0) {
+    return "weeks";
+  }
+  return "days";
+};
+
+/**
+ * Converts days to the display value for the specified time unit.
+ */
+const convertDaysToDisplayValue = (days: number, unit: TimeUnit) => {
+  return days / timeMultipliers[unit];
+};
+
+/**
+ * Converts display value to days based on the time unit.
+ */
+const convertDisplayValueToDays = (displayValue: number, unit: TimeUnit) => {
+  return displayValue * timeMultipliers[unit];
+};
+
+/**
+ * Formats a duration in days to a human-readable string with the optimal time unit.
+ */
+export const formatDuration = (days: Nil<number>): string => {
+  if (!days) return "0 days";
+
+  const unit = getOptimalTimeUnit(days);
+  const value = convertDaysToDisplayValue(days, unit);
+
+  const formattedUnit = value === 1 ? unit.slice(0, -1) : unit; // singular if value is 1
+  return `${value} ${formattedUnit}`;
+};
+
+/**
+ * Initializes the component state based on the provided value.
+ */
+const getInitialState = (value?: ComponentProps<typeof Input>["value"]) => {
+  const numericValue = value ? parseFloat(value.toString()) : NaN;
+  const isValidValue = !isNaN(numericValue) && numericValue >= 0;
+
+  if (!isValidValue) {
+    return {
+      timeUnit: "days" as TimeUnit,
+      inputValue: value?.toString() ?? "",
+    };
+  }
+
+  const timeUnit = getOptimalTimeUnit(numericValue);
+  const displayValue = convertDaysToDisplayValue(numericValue, timeUnit);
+
+  return {
+    timeUnit,
+    inputValue: displayValue.toString(),
+  };
+};
+
+export const DurationInput = ({
+  onChange,
+  value,
+  ...props
+}: DurationInputProps) => {
+  const initialState = getInitialState(value);
+
+  const [timeUnit, setTimeUnit] = useState(initialState.timeUnit);
+  const [inputValue, setInputValue] = useState(initialState.inputValue);
+
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const newInputValue = event.target.value;
+    setInputValue(newInputValue);
+
+    if (newInputValue === "") {
+      onChange?.(null);
+      return;
+    }
+
+    const numericValue = parseFloat(newInputValue);
+    if (!isNaN(numericValue)) {
+      const daysValue = convertDisplayValueToDays(numericValue, timeUnit);
+      onChange?.(daysValue);
+    }
+  };
+
+  const handleTimeUnitChange = (newTimeUnit: TimeUnit) => {
+    setTimeUnit(newTimeUnit);
+
+    if (inputValue === "") {
+      onChange?.(null);
+      return;
+    }
+
+    const numericValue = parseFloat(inputValue);
+    if (!isNaN(numericValue)) {
+      const daysValue = convertDisplayValueToDays(numericValue, newTimeUnit);
+      onChange?.(daysValue);
+    }
+  };
+
+  return (
+    <div className="flex gap-2">
+      <Input
+        type="number"
+        value={inputValue}
+        onChange={handleInputChange}
+        {...props}
+      />
+      <Select value={timeUnit} onValueChange={handleTimeUnitChange}>
+        <SelectTrigger className="!w-40">
+          <SelectValue placeholder="days" className="w-40" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            <SelectItem value="days">days</SelectItem>
+            <SelectItem value="weeks">weeks</SelectItem>
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+    </div>
+  );
+};

--- a/src/routes/~(dashboard)/~$team/~$study/~configuration/components/EnrollmentCard.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~configuration/components/EnrollmentCard.tsx
@@ -11,6 +11,7 @@ import {
   formatNilDateRange,
 } from "@stanfordspezi/spezi-web-design-system";
 import { useParams } from "@tanstack/react-router";
+import { formatDuration } from "@/components/interfaces/DurationInput";
 import { KeyValueCard } from "@/components/interfaces/KeyValueCard";
 import { formatLogicClauses } from "@/components/interfaces/LogicGroupInput/formatLogicClauses";
 import { EditButtonLink } from "@/components/ui/EditButton";
@@ -58,7 +59,7 @@ export const EnrollmentCard = ({ study, isLoading }: EnrollmentCardProps) => {
           key: "Study duration",
           tooltip:
             "The number of days each participant stays in the study from their individual start date.",
-          value: study?.studyDuration,
+          value: formatDuration(study?.studyDuration),
         },
         {
           key: "Private study",

--- a/src/routes/~(dashboard)/~$team/~$study/~configuration/components/EnrollmentForm.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~configuration/components/EnrollmentForm.tsx
@@ -6,12 +6,8 @@
 // SPDX-License-Identifier: MIT
 //
 
-import {
-  Input,
-  Field,
-  Label,
-  Switch,
-} from "@stanfordspezi/spezi-web-design-system";
+import { Field, Label, Switch } from "@stanfordspezi/spezi-web-design-system";
+import { DurationInput } from "@/components/interfaces/DurationInput";
 import { formatLogicClausesError } from "@/components/interfaces/LogicGroupInput/formatLogicClausesError";
 import { LogicGroupInput } from "@/components/interfaces/LogicGroupInput/LogicGroupInput";
 import { Card } from "@/components/ui/Card";
@@ -63,21 +59,10 @@ export const EnrollmentForm = ({ form, onSubmit }: EnrollmentFormProps) => {
           label={
             <FieldLabel
               title="Study Duration"
-              description="The number of days each participant stays in the study from their individual start date."
+              description="The duration each participant stays in the study from their individual start date."
             />
           }
-          render={({ field }) => (
-            <div className="relative">
-              <Input
-                type="number"
-                className="pr-14"
-                {...enhanceField(field, { valueAsNumber: true })}
-              />
-              <div className="text-text-tertiary absolute top-1/2 right-4 -translate-y-1/2 text-sm select-none">
-                days
-              </div>
-            </div>
-          )}
+          render={({ field }) => <DurationInput {...enhanceField(field)} />}
           className="px-6 pt-6"
         />
       </Card>

--- a/src/routes/~(dashboard)/~$team/~$study/~configuration/lib/formatSchedule.ts
+++ b/src/routes/~(dashboard)/~$team/~$study/~configuration/lib/formatSchedule.ts
@@ -7,6 +7,7 @@
 //
 
 import type { z } from "zod";
+import { formatDuration } from "@/components/interfaces/DurationInput";
 import type { scheduleSchema } from "@/server/database/entities/component/schema";
 
 /**
@@ -82,7 +83,7 @@ export const formatSchedule = ({
 
   const startString =
     startOffset === 0 ? "Starts immediately" : (
-      `Starts after ${startOffset} ${startOffset === 1 ? "day" : "days"}`
+      `Starts after ${formatDuration(startOffset)}`
     );
 
   return `${frequencyString} at ${timeString}. ${startString}.`;

--- a/src/routes/~(dashboard)/~$team/~$study/~configuration/~components/components/EditComponentLayout.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~configuration/~components/components/EditComponentLayout.tsx
@@ -20,11 +20,13 @@ import { ScheduleDialog } from "./ScheduleDialog";
 interface ComponentsLayoutProps {
   children: ReactNode;
   saveButton: ReactNode;
+  showScheduleButton?: boolean;
 }
 
 export const EditComponentLayout = ({
   children,
   saveButton,
+  showScheduleButton = true,
 }: ComponentsLayoutProps) => {
   const params = useParams({
     from: "/(dashboard)/$team/$study/configuration/components/$component",
@@ -56,7 +58,7 @@ export const EditComponentLayout = ({
               >
                 Delete
               </Button>
-              <ScheduleDialog />
+              {showScheduleButton && <ScheduleDialog />}
               {saveButton}
             </div>
           }

--- a/src/routes/~(dashboard)/~$team/~$study/~configuration/~components/components/HealthDataComponentForm.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~configuration/~components/components/HealthDataComponentForm.tsx
@@ -1,0 +1,93 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { Field } from "@stanfordspezi/spezi-web-design-system";
+import type { BaseSyntheticEvent } from "react";
+import { DurationInput } from "@/components/interfaces/DurationInput";
+import { CardHeader } from "@/components/ui/Card";
+import { FieldLabel } from "@/components/ui/FieldLabel";
+import {
+  MultiSelect,
+  MultiSelectContent,
+  MultiSelectGroup,
+  MultiSelectItem,
+  MultiSelectTrigger,
+  MultiSelectValue,
+} from "@/components/ui/MultiSelect";
+import { enhanceField } from "@/utils/enhanceField";
+import { healthDataTypes } from "../../lib/healthDataTypes";
+import type { ComponentForm } from "../../lib/useComponentForm";
+
+interface HealthDataComponentFormProps {
+  form: ComponentForm;
+  onSubmit: (event?: BaseSyntheticEvent) => Promise<void>;
+}
+
+export const HealthDataComponentForm = ({
+  form,
+  onSubmit,
+}: HealthDataComponentFormProps) => {
+  return (
+    <>
+      <CardHeader
+        title="Health Data Component"
+        description="Collect health data from participants."
+      />
+      <form onSubmit={onSubmit} className="py-6">
+        <Field
+          control={form.control}
+          name="historicalDataCollection"
+          label={
+            <FieldLabel
+              title="Historical data collection"
+              description="The amount of past health data to collect when a participant first enrolls in the study."
+            />
+          }
+          render={({ field }) => <DurationInput {...enhanceField(field)} />}
+          className="border-border-tertiary border-b px-6"
+        />
+        <Field
+          control={form.control}
+          name="sampleTypes"
+          label={
+            <FieldLabel
+              title="Sample types"
+              description="The types of health data to collect from participants."
+            />
+          }
+          render={({ field }) => (
+            <MultiSelect values={field.value} onValuesChange={field.onChange}>
+              <MultiSelectTrigger>
+                <MultiSelectValue
+                  className="[&_[data-selected-item=true]]:bg-fill-tertiary"
+                  overflowBehavior="wrap"
+                />
+              </MultiSelectTrigger>
+              <MultiSelectContent>
+                {Object.entries(healthDataTypes).map(([category, values]) => (
+                  <MultiSelectGroup key={category} heading={category}>
+                    {values.map(({ label, value }) => (
+                      <MultiSelectItem
+                        key={value}
+                        value={value}
+                        keywords={[label, category]}
+                      >
+                        {label}
+                      </MultiSelectItem>
+                    ))}
+                  </MultiSelectGroup>
+                ))}
+              </MultiSelectContent>
+            </MultiSelect>
+          )}
+          className="px-6 pt-6"
+        />
+      </form>
+    </>
+  );
+};

--- a/src/routes/~(dashboard)/~$team/~$study/~configuration/~components/components/InformationComponentForm.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~configuration/~components/components/InformationComponentForm.tsx
@@ -17,12 +17,12 @@ import type { ComponentForm } from "../../lib/useComponentForm";
 
 interface InformationComponentFormProps {
   form: ComponentForm;
-  onSave: (event?: BaseSyntheticEvent) => Promise<void>;
+  onSubmit: (event?: BaseSyntheticEvent) => Promise<void>;
 }
 
 export const InformationComponentForm = ({
   form,
-  onSave,
+  onSubmit,
 }: InformationComponentFormProps) => {
   return (
     <>
@@ -30,7 +30,7 @@ export const InformationComponentForm = ({
         title="Information Component"
         description="Display text and images to provide instructions, explanations, or context to participants."
       />
-      <form onSubmit={onSave} className="py-6">
+      <form onSubmit={onSubmit} className="py-6">
         <Field
           control={form.control}
           name="title"

--- a/src/routes/~(dashboard)/~$team/~$study/~configuration/~components/components/QuestionnaireComponentForm.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~configuration/~components/components/QuestionnaireComponentForm.tsx
@@ -1,0 +1,167 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Study Platform open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import {
+  Button,
+  Field,
+  Textarea,
+} from "@stanfordspezi/spezi-web-design-system";
+import { useRef, type BaseSyntheticEvent, type ChangeEvent } from "react";
+import { CardHeader } from "@/components/ui/Card";
+import { FieldLabel } from "@/components/ui/FieldLabel";
+import type { ComponentForm } from "../../lib/useComponentForm";
+
+interface QuestionnaireComponentFormProps {
+  form: ComponentForm;
+  onSubmit: (event?: BaseSyntheticEvent) => Promise<void>;
+}
+
+export const QuestionnaireComponentForm = ({
+  form,
+  onSubmit,
+}: QuestionnaireComponentFormProps) => {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const questionnaireValue = form.watch("fhirQuestionnaireJson");
+
+  const handleUploadClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileUpload = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+
+    if (!file) return;
+
+    try {
+      const text = await file.text();
+      const parsed = JSON.parse(text);
+      const formatted = JSON.stringify(parsed, null, 2);
+
+      form.setValue("fhirQuestionnaireJson", formatted, {
+        shouldDirty: true,
+        shouldTouch: true,
+        shouldValidate: true,
+      });
+      form.clearErrors("fhirQuestionnaireJson");
+    } catch {
+      form.setError("fhirQuestionnaireJson", {
+        message: "Invalid JSON file. Please upload a valid JSON document.",
+      });
+    } finally {
+      event.target.value = "";
+    }
+  };
+
+  const handleDownload = () => {
+    if (!questionnaireValue.trim()) {
+      form.setError("fhirQuestionnaireJson", {
+        message: "There is no JSON to download yet.",
+      });
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(questionnaireValue);
+      const formatted = JSON.stringify(parsed, null, 2);
+      const blob = new Blob([formatted], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = "questionnaire.json";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+      form.clearErrors("fhirQuestionnaireJson");
+    } catch {
+      form.setError("fhirQuestionnaireJson", {
+        message: "JSON is invalid. Please fix it before downloading.",
+      });
+    }
+  };
+
+  const handleFormat = () => {
+    if (!questionnaireValue.trim()) return;
+
+    try {
+      const parsed = JSON.parse(questionnaireValue);
+      const formatted = JSON.stringify(parsed, null, 2);
+
+      form.setValue("fhirQuestionnaireJson", formatted, {
+        shouldDirty: true,
+        shouldTouch: true,
+        shouldValidate: true,
+      });
+      form.clearErrors("fhirQuestionnaireJson");
+    } catch {
+      form.setError("fhirQuestionnaireJson", {
+        message: "JSON is invalid. Please fix it before formatting.",
+      });
+    }
+  };
+
+  return (
+    <>
+      <CardHeader
+        title="Questionnaire Component"
+        description="Collect questionnaire responses from participants."
+      />
+      <form onSubmit={onSubmit} className="py-6">
+        <Field
+          control={form.control}
+          name="fhirQuestionnaireJson"
+          label={
+            <FieldLabel
+              title="FHIR Questionnaire JSON"
+              description="The FHIR Questionnaire JSON to collect responses from participants."
+            />
+          }
+          render={({ field }) => (
+            <div>
+              <Textarea {...field} rows={10} className="w-full font-mono" />
+              <div className="flex flex-wrap justify-end gap-2 pt-4">
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="application/json,application/fhir+json"
+                  className="hidden"
+                  onChange={handleFileUpload}
+                />
+                <Button
+                  type="button"
+                  size="xs"
+                  variant="outlineBg"
+                  onClick={handleUploadClick}
+                >
+                  Upload JSON
+                </Button>
+                <Button
+                  type="button"
+                  size="xs"
+                  variant="outlineBg"
+                  onClick={handleDownload}
+                >
+                  Download JSON
+                </Button>
+                <Button
+                  type="button"
+                  size="xs"
+                  variant="outlineBg"
+                  onClick={handleFormat}
+                >
+                  Format JSON
+                </Button>
+              </div>
+            </div>
+          )}
+          className="px-6"
+        />
+      </form>
+    </>
+  );
+};

--- a/src/routes/~(dashboard)/~$team/~$study/~configuration/~components/components/ScheduleDialog.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~configuration/~components/components/ScheduleDialog.tsx
@@ -28,6 +28,7 @@ import {
   useOpenState,
 } from "@stanfordspezi/spezi-web-design-system";
 import { CalendarSync } from "lucide-react";
+import { DurationInput } from "@/components/interfaces/DurationInput";
 import { FeaturedIconContainer } from "@/components/ui/FeaturedIconContainer";
 import { FieldLabel } from "@/components/ui/FieldLabel";
 import { TimeSelect } from "@/components/ui/TimeSelect";
@@ -120,21 +121,10 @@ export const ScheduleDialog = () => {
               label={
                 <FieldLabel
                   title="Start offset"
-                  description="Number of days to wait after enrollment before showing this component."
+                  description="Duration to wait after enrollment before showing this component."
                 />
               }
-              render={({ field }) => (
-                <div className="relative">
-                  <Input
-                    type="number"
-                    className="pr-14"
-                    {...enhanceField(field, { valueAsNumber: true })}
-                  />
-                  <div className="text-text-tertiary absolute top-1/2 right-4 -translate-y-1/2 text-sm select-none">
-                    days
-                  </div>
-                </div>
-              )}
+              render={({ field }) => <DurationInput {...enhanceField(field)} />}
               className="border-border-tertiary bg-layer border-y px-6 pt-6"
             />
             <div className="border-border-tertiary bg-layer flex gap-8 border-b px-6 pt-6">

--- a/src/routes/~(dashboard)/~$team/~$study/~configuration/~components/~$component.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~configuration/~components/~$component.tsx
@@ -15,6 +15,8 @@ import { useUpdateComponentMutation } from "@/lib/queries/component";
 import { EditComponentLayout } from "./components/EditComponentLayout";
 import { InformationComponentForm } from "./components/InformationComponentForm";
 import { useComponentForm } from "../lib/useComponentForm";
+import { HealthDataComponentForm } from "./components/HealthDataComponentForm";
+import { QuestionnaireComponentForm } from "./components/QuestionnaireComponentForm";
 
 const EditComponentRoute = () => {
   const params = Route.useParams();
@@ -45,6 +47,7 @@ const EditComponentRoute = () => {
 
   return (
     <EditComponentLayout
+      showScheduleButton={componentType !== "health-data"}
       saveButton={
         <SaveButton
           size="sm"
@@ -59,7 +62,13 @@ const EditComponentRoute = () => {
       <div className="flex max-w-4xl p-6">
         <Card>
           {componentType === "information" && (
-            <InformationComponentForm form={form} onSave={handleSave} />
+            <InformationComponentForm form={form} onSubmit={handleSave} />
+          )}
+          {componentType === "questionnaire" && (
+            <QuestionnaireComponentForm form={form} onSubmit={handleSave} />
+          )}
+          {componentType === "health-data" && (
+            <HealthDataComponentForm form={form} onSubmit={handleSave} />
           )}
         </Card>
       </div>

--- a/src/routes/~(dashboard)/~$team/~$study/~configuration/~components/~new.tsx
+++ b/src/routes/~(dashboard)/~$team/~$study/~configuration/~components/~new.tsx
@@ -16,6 +16,8 @@ import { useCreateComponentMutation } from "@/lib/queries/component";
 import { InformationComponentForm } from "./components/InformationComponentForm";
 import { NewComponentLayout } from "./components/NewComponentLayout";
 import { useComponentForm } from "../lib/useComponentForm";
+import { HealthDataComponentForm } from "./components/HealthDataComponentForm";
+import { QuestionnaireComponentForm } from "./components/QuestionnaireComponentForm";
 
 const NewComponentRoute = () => {
   const { componentType = "information" } = Route.useSearch();
@@ -63,7 +65,13 @@ const NewComponentRoute = () => {
       <div className="flex max-w-4xl p-6">
         <Card>
           {componentType === "information" && (
-            <InformationComponentForm form={form} onSave={handleSave} />
+            <InformationComponentForm form={form} onSubmit={handleSave} />
+          )}
+          {componentType === "questionnaire" && (
+            <QuestionnaireComponentForm form={form} onSubmit={handleSave} />
+          )}
+          {componentType === "health-data" && (
+            <HealthDataComponentForm form={form} onSubmit={handleSave} />
           )}
         </Card>
       </div>

--- a/src/server/database/entities/component/fixtures.ts
+++ b/src/server/database/entities/component/fixtures.ts
@@ -51,4 +51,12 @@ export const componentFixtures: Component[] = [
       completionPolicy: "anytime",
     },
   },
+  {
+    id: "comp_health_data",
+    studyId: "study_activity",
+    type: "health-data",
+    sampleTypes: ["HKCategoryType;HKCategoryTypeIdentifierAppleStandHour"],
+    historicalDataCollection: 7,
+    schedule: null,
+  },
 ];


### PR DESCRIPTION
# Add missing component flows

<img width="1920" height="1080" alt="11shots_so" src="https://github.com/user-attachments/assets/5bd1abb0-1e6d-44f0-ba27-ddca2af7a148" />

## :recycle: Current situation & Problem
The app is missing the health data and questionnaire pages.

## :gear: Release Notes

### New UI Components and Forms
-  **Duration Input**: Added `DurationInput.tsx` for flexible time entry (days/weeks with automatic unit switching for optimal display, e.g., "2 weeks" instead of "14 days"). Includes conversion logic, validation, and singular/plural formatting. Integrated into multiple forms for study duration, historical data, and schedule offsets.
-  **Health Data Form**: Created `HealthDataComponentForm.tsx` with MultiSelect for choosing sample types (categorized by health data types like Heart Rate, Sleep Analysis). Supports historical data collection via DurationInput and required validation (at least one sample type).
-  **Questionnaire Form**: New `QuestionnaireComponentForm.tsx` for FHIR JSON input with Textarea editor. Features upload/download buttons for JSON files (with validation and formatting), a "Format JSON" button (prettifies with 2-space indentation), and error handling for invalid JSON.

### Routing and Workflow Enhancements
-  **Component Creation/Editing Routes**: Updated `new.tsx` and `edit.tsx` to handle all component types (information, health-data, questionnaire) with conditional rendering of type-specific forms. Standardized prop names (e.g., `onSubmit` instead of `onSave`). Added navigation logic and hotkey support (Cmd+Enter).
-  **Edit Layout**: Modified `EditComponentLayout.tsx` to conditionally show/hide the ScheduleDialog button (disabled for health-data components, as they may not need scheduling). Includes delete functionality with navigation back to the components list.

## :white_check_mark: Testing
Extended `components.spec.ts` with tests for health data and questionnaire components.

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
